### PR TITLE
Boot delay

### DIFF
--- a/boot/main.c
+++ b/boot/main.c
@@ -82,8 +82,8 @@ void led_task() {
 }
 
 void bootloader_main() {
-	if (PM->RCAUSE.reg & PM_RCAUSE_POR) {
-		// On powerup, force a clean reset of the MT7620
+	if (PM->RCAUSE.reg & (PM_RCAUSE_POR | PM_RCAUSE_BOD12 | PM_RCAUSE_BOD33)) {
+		// On powerup, power off MT7620
 		pin_low(PIN_SOC_RST);
 		pin_out(PIN_SOC_RST);
 	}

--- a/common/board.h
+++ b/common/board.h
@@ -27,6 +27,7 @@ const static Pin PIN_USB_DP = {.group = 0, .pin = 25, .mux = MUX_PA25G_USB_DP };
 // Power
 
 const static Pin PIN_SOC_RST = {.group = 0, .pin = 3};
+const static Pin PIN_18_V = {.group = 1, .pin = 3}; // pin for 1.8V line
 const static Pin PIN_SOC_PWR = {.group = 0, .pin = 27};
 
 const static Pin PIN_LED = {.group = 0, .pin = 6};

--- a/firmware/firmware.h
+++ b/firmware/firmware.h
@@ -36,6 +36,7 @@
 
 /// Timer allocation
 #define TC_TERMINAL_TIMEOUT 3
+#define TC_BOOT             4
 
 // TCC allocation
 // muxed with i2c. also used for uart read timers

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -3,14 +3,36 @@
 PortData port_a;
 PortData port_b;
 
+// int flagCount = 0;
+
 int main(void) {
+    clock_init_crystal(GCLK_SYSTEM, GCLK_32K);
+
     if (PM->RCAUSE.reg & PM_RCAUSE_POR) {
         // On powerup, force a clean reset of the MT7620
         pin_low(PIN_SOC_RST);
         pin_out(PIN_SOC_RST);
-    }
+    
+        // do while delay
+        // 50 milliseconds
+        timer_clock_enable(TC_BOOT);
 
-    clock_init_crystal(GCLK_SYSTEM, GCLK_32K);
+        tc(TC_BOOT)->COUNT16.CTRLA.reg
+        = TC_CTRLA_WAVEGEN_MPWM
+        | TC_CTRLA_PRESCALER_DIV256; // 32kHz * 256 prescale = 8miliseconds per tick
+
+        tc(TC_BOOT)->COUNT16.CC[0].reg = 7; // 8*7 = 56ms
+
+        while (tc(TC_BOOT)->COUNT16.STATUS.bit.SYNCBUSY);
+        tc(TC_BOOT)->COUNT16.CTRLA.bit.ENABLE = 1;
+
+        while(!tc(TC_BOOT)->COUNT16.INTFLAG.bit.MC0) {
+            // flagCount = tc(TC_BOOT)->COUNT16.COUNT.reg;
+            // hold off on booting
+        }
+        // disable timer
+        tc(TC_BOOT)->COUNT16.CTRLA.bit.ENABLE = 0;
+    }
 
     pin_mux(PIN_USB_DM);
     pin_mux(PIN_USB_DP);

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -3,33 +3,37 @@
 PortData port_a;
 PortData port_b;
 
-// int flagCount = 0;
-
 int main(void) {
     clock_init_crystal(GCLK_SYSTEM, GCLK_32K);
+
+    // pin_high(PORT_A.power);
+    // pin_out(PORT_A.power);
 
     if (PM->RCAUSE.reg & PM_RCAUSE_POR) {
         // On powerup, force a clean reset of the MT7620
         pin_low(PIN_SOC_RST);
         pin_out(PIN_SOC_RST);
-    
+
+        // pin_high(PORT_A.g3);
+        // pin_out(PORT_A.g3);
         // do while delay
         // 50 milliseconds
         timer_clock_enable(TC_BOOT);
 
         tc(TC_BOOT)->COUNT16.CTRLA.reg
         = TC_CTRLA_WAVEGEN_MPWM
-        | TC_CTRLA_PRESCALER_DIV256; // 32kHz * 256 prescale = 8miliseconds per tick
-
-        tc(TC_BOOT)->COUNT16.CC[0].reg = 7; // 8*7 = 56ms
+        | TC_CTRLA_PRESCALER_DIV1024; 
+        tc(TC_BOOT)->COUNT16.CC[0].reg = 2500; //  ~50ms
 
         while (tc(TC_BOOT)->COUNT16.STATUS.bit.SYNCBUSY);
         tc(TC_BOOT)->COUNT16.CTRLA.bit.ENABLE = 1;
+        // pin_low(PORT_A.g3);
 
         while(!tc(TC_BOOT)->COUNT16.INTFLAG.bit.MC0) {
-            // flagCount = tc(TC_BOOT)->COUNT16.COUNT.reg;
             // hold off on booting
         }
+        // pin_high(PORT_A.g3);
+        
         // disable timer
         tc(TC_BOOT)->COUNT16.CTRLA.bit.ENABLE = 0;
     }

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -33,6 +33,7 @@ int main(void) {
 
     // if (PM->RCAUSE.reg & PM_RCAUSE_POR) {
         // On powerup, force a clean reset of the MT7620
+        
         pin_low(PIN_SOC_RST);
         pin_out(PIN_SOC_RST);
 
@@ -44,9 +45,14 @@ int main(void) {
         pin_low(PIN_18_V);
         pin_out(PIN_18_V);
 
-        pin_low(PORT_A.g3);
         clock_init_crystal(GCLK_SYSTEM, GCLK_32K);
         timer_clock_enable(TC_BOOT);
+
+        // hold everything low
+
+        pin_low(PORT_A.g3);
+        pin_high(PORT_A.g3);
+        boot_delay_ms(200); // power off for 200ms
 
         pin_high(PORT_A.g3);
         pin_low(PORT_A.g3);

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -42,7 +42,7 @@ int main(void) {
         timer_clock_enable(TC_BOOT);
 
         // hold everything low
-        boot_delay_ms(200); // power off for 200ms
+        boot_delay_ms(50); // power off for 50ms
 
         pin_high(PIN_SOC_PWR);
 

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -25,7 +25,7 @@ void boot_delay_ms(int delay){
 }
 
 int main(void) {
-    if (PM->RCAUSE.reg & PM_RCAUSE_POR) {
+    if (PM->RCAUSE.reg & (PM_RCAUSE_POR | PM_RCAUSE_BOD12 | PM_RCAUSE_BOD33)) {
         // On powerup, force a clean reset of the MT7620
         pin_low(PIN_SOC_RST);
         pin_out(PIN_SOC_RST);

--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -293,13 +293,21 @@ bool usb_cb_set_configuration(uint8_t config) {
 void req_gpio(uint16_t wIndex, uint16_t wValue) {
 	if ( (wIndex & 0xF0) == REQ_PWR_PORT_A_IO 
 		&& (wIndex & 0x0F) < 8 ) {
-		pin_dir(PORT_A.gpio[wIndex & 0x7], 1);
-		pin_set(PORT_A.gpio[wIndex & 0x7], wValue);
+		if (wValue == 2) {
+			pin_in(PORT_A.gpio[wIndex & 0x7]);
+		} else {
+			pin_dir(PORT_A.gpio[wIndex & 0x7], 1);
+			pin_set(PORT_A.gpio[wIndex & 0x7], wValue);
+		}
 	} else if (
 		(wIndex & 0xF0) == REQ_PWR_PORT_B_IO 
 		&& (wIndex & 0x0F) < 8 ){
-		pin_dir(PORT_B.gpio[wIndex & 0x7], 1);
-		pin_set(PORT_B.gpio[wIndex & 0x7], wValue);
+		if (wValue == 2) {
+			pin_in(PORT_B.gpio[wIndex & 0x7]);
+		} else {
+			pin_dir(PORT_B.gpio[wIndex & 0x7], 1);
+			pin_set(PORT_B.gpio[wIndex & 0x7], wValue);
+		}
 	} else {
 		switch (wIndex) {
 			case REQ_PWR_RST:

--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -291,60 +291,13 @@ bool usb_cb_set_configuration(uint8_t config) {
 #define REQ_INFO_GIT_HASH 0x0
 
 void req_gpio(uint16_t wIndex, uint16_t wValue) {
-	if ( (wIndex ^ REQ_PWR_PORT_A_IO) < 8 ) {
-		switch (wIndex ^ REQ_PWR_PORT_A_IO) {
-			case 0x0:
-				pin_set(PORT_A.scl, wValue);
-				break;
-			case 0x1:
-				pin_set(PORT_A.sda, wValue);
-				break;
-			case 0x2:
-				pin_set(PORT_A.sck, wValue);
-				break;
-			case 0x3:
-				pin_set(PORT_A.miso, wValue);
-				break;
-			case 0x4:
-				pin_set(PORT_A.mosi, wValue);
-				break;
-			case 0x5:
-				pin_set(PORT_A.tx, wValue);
-				break;
-			case 0x6:
-				pin_set(PORT_A.rx, wValue);
-				break;
-			case 0x7:
-				pin_set(PORT_A.g3, wValue);
-				break;
-		}
-	} else if ((wIndex ^ REQ_PWR_PORT_B_IO) < 8) {
-		switch (wIndex ^ REQ_PWR_PORT_B_IO) {
-			case 0x0:
-				pin_set(PORT_B.scl, wValue);
-				break;
-			case 0x1:
-				pin_set(PORT_B.sda, wValue);
-				break;
-			case 0x2:
-				pin_set(PORT_B.sck, wValue);
-				break;
-			case 0x3:
-				pin_set(PORT_B.miso, wValue);
-				break;
-			case 0x4:
-				pin_set(PORT_B.mosi, wValue);
-				break;
-			case 0x5:
-				pin_set(PORT_B.tx, wValue);
-				break;
-			case 0x6:
-				pin_set(PORT_B.rx, wValue);
-				break;
-			case 0x7:
-				pin_set(PORT_B.g3, wValue);
-				break;
-		}
+	if ( (wIndex & 0xF0) == REQ_PWR_PORT_A_IO 
+		&& (wIndex & 0x0F) < 8 ) {
+		pin_set(PORT_A.gpio[wIndex & 0x7], wValue);
+	} else if (
+		(wIndex & 0xF0) == REQ_PWR_PORT_B_IO 
+		&& (wIndex & 0x0F) < 8 ){
+		pin_set(PORT_B.gpio[wIndex & 0x7], wValue);
 	} else {
 		switch (wIndex) {
 			case REQ_PWR_RST:

--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -286,30 +286,88 @@ bool usb_cb_set_configuration(uint8_t config) {
 #define REQ_PWR_PORT_B 0x11
 #define REQ_PWR_LED 0x20
 #define REQ_INFO 0x30
+#define REQ_PWR_PORT_A_IO 0x40
+#define REQ_PWR_PORT_B_IO 0x50
 #define REQ_INFO_GIT_HASH 0x0
 
 void req_gpio(uint16_t wIndex, uint16_t wValue) {
-	switch (wIndex) {
-		case REQ_PWR_RST:
-			pin_low(PIN_SOC_RST);
-			pin_dir(PIN_SOC_RST, !wValue);
-			break;
-		case REQ_PWR_SOC:
-			pin_set(PIN_SOC_PWR, wValue);
-			break;
-		case REQ_PWR_PORT_A:
-			pin_set(PORT_A.power, wValue);
-			break;
-		case REQ_PWR_PORT_B:
-			pin_set(PORT_B.power, wValue);
-			break;
-		case REQ_PWR_LED:
-			pin_set(PIN_LED, wValue);
-			break;
-		default:
-			return usb_ep0_stall();
+	if ( (wIndex ^ REQ_PWR_PORT_A_IO) < 8 ) {
+		switch (wIndex ^ REQ_PWR_PORT_A_IO) {
+			case 0x0:
+				pin_set(PORT_A.scl, wValue);
+				break;
+			case 0x1:
+				pin_set(PORT_A.sda, wValue);
+				break;
+			case 0x2:
+				pin_set(PORT_A.sck, wValue);
+				break;
+			case 0x3:
+				pin_set(PORT_A.miso, wValue);
+				break;
+			case 0x4:
+				pin_set(PORT_A.mosi, wValue);
+				break;
+			case 0x5:
+				pin_set(PORT_A.tx, wValue);
+				break;
+			case 0x6:
+				pin_set(PORT_A.rx, wValue);
+				break;
+			case 0x7:
+				pin_set(PORT_A.g3, wValue);
+				break;
+		}
+	} else if ((wIndex ^ REQ_PWR_PORT_B_IO) < 8) {
+		switch (wIndex ^ REQ_PWR_PORT_B_IO) {
+			case 0x0:
+				pin_set(PORT_B.scl, wValue);
+				break;
+			case 0x1:
+				pin_set(PORT_B.sda, wValue);
+				break;
+			case 0x2:
+				pin_set(PORT_B.sck, wValue);
+				break;
+			case 0x3:
+				pin_set(PORT_B.miso, wValue);
+				break;
+			case 0x4:
+				pin_set(PORT_B.mosi, wValue);
+				break;
+			case 0x5:
+				pin_set(PORT_B.tx, wValue);
+				break;
+			case 0x6:
+				pin_set(PORT_B.rx, wValue);
+				break;
+			case 0x7:
+				pin_set(PORT_B.g3, wValue);
+				break;
+		}
+	} else {
+		switch (wIndex) {
+			case REQ_PWR_RST:
+				pin_low(PIN_SOC_RST);
+				pin_dir(PIN_SOC_RST, !wValue);
+				break;
+			case REQ_PWR_SOC:
+				pin_set(PIN_SOC_PWR, wValue);
+				break;
+			case REQ_PWR_PORT_A:
+				pin_set(PORT_A.power, wValue);
+				break;
+			case REQ_PWR_PORT_B:
+				pin_set(PORT_B.power, wValue);
+				break;
+			case REQ_PWR_LED:
+				pin_set(PIN_LED, wValue);
+				break;
+			default:
+				return usb_ep0_stall();
+		}
 	}
-
+	
 	usb_ep0_out();
 	return usb_ep0_in(0);
 }

--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -293,10 +293,12 @@ bool usb_cb_set_configuration(uint8_t config) {
 void req_gpio(uint16_t wIndex, uint16_t wValue) {
 	if ( (wIndex & 0xF0) == REQ_PWR_PORT_A_IO 
 		&& (wIndex & 0x0F) < 8 ) {
+		pin_dir(PORT_A.gpio[wIndex & 0x7], 1);
 		pin_set(PORT_A.gpio[wIndex & 0x7], wValue);
 	} else if (
 		(wIndex & 0xF0) == REQ_PWR_PORT_B_IO 
 		&& (wIndex & 0x0F) < 8 ){
+		pin_dir(PORT_B.gpio[wIndex & 0x7], 1);
 		pin_set(PORT_B.gpio[wIndex & 0x7], wValue);
 	} else {
 		switch (wIndex) {


### PR DESCRIPTION
rails should come up according to the following:
* 3.3V
* 800uS Delay
* 1.8V
* 50ms Delay
* PORST

Added a 200ms delay at the beginning because we can't control the rails right as they come up. Alternative is to shut down the SoC and bring it up again according to those delays.