### PR TITLE
testrig: Put the SWD adaptor on a non-default altsetting

### DIFF
--- a/test_rig/dap_hid.c
+++ b/test_rig/dap_hid.c
@@ -12,6 +12,14 @@ void dap_enable() {
     usb_ep_start_out(USB_EP_DAP_HID_OUT, dap_buf_out, DAP_PACKET_SIZE);
 }
 
+void dap_disable() {
+    pin_in(PIN_SWCLK);
+    pin_in(PIN_SWDIO);
+    pin_in(PIN_RESET);
+    usb_disable_ep(USB_EP_DAP_HID_OUT);
+    usb_disable_ep(USB_EP_DAP_HID_IN);
+}
+
 void dap_handle_usb_in_completion() {
     usb_ep_start_out(USB_EP_DAP_HID_OUT, dap_buf_out, DAP_PACKET_SIZE);
 }

--- a/test_rig/test_rig.h
+++ b/test_rig/test_rig.h
@@ -25,6 +25,7 @@
 
 // dap_hid.c
 void dap_enable();
+void dap_disable();
 void dap_handle_usb_in_completion();
 void dap_handle_usb_out_completion();
 


### PR DESCRIPTION
So all state gets reset between processes

Requires a corresponding change to t2-test-rig-sw