### PR TITLE
Enter bootloader on USB command

### DIFF
--- a/boot/main.c
+++ b/boot/main.c
@@ -136,8 +136,12 @@ bool button_pressed() {
 	return !pin_read(PIN_BTN);
 }
 
+bool bootloader_sw_triggered() {
+	return PM->RCAUSE.reg & PM_RCAUSE_WDT;
+}
+
 int main() {
-	if (!flash_valid() || button_pressed()) {
+	if (!flash_valid() || button_pressed() || bootloader_sw_triggered()) {
 		bootloader_main();
 	}
 

--- a/common/hw.h
+++ b/common/hw.h
@@ -236,3 +236,13 @@ void timer_clock_enable(TimerId id);
 void tcc_delay_start(TimerId id, u32 ticks);
 void tcc_delay_disable(TimerId id);
 void tcc_delay_enable(TimerId id);
+
+// wdt
+
+inline static void wdt_reset(u32 clock_channel) {
+  GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN |
+      GCLK_CLKCTRL_GEN(clock_channel) |
+      GCLK_CLKCTRL_ID(WDT_GCLK_ID);
+  WDT->CONFIG.reg = 0x7; // 31ms
+  WDT->CTRL.reg = WDT_CTRL_ENABLE;
+}

--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -289,6 +289,7 @@ bool usb_cb_set_configuration(uint8_t config) {
 #define REQ_PWR_PORT_A_IO 0x40
 #define REQ_PWR_PORT_B_IO 0x50
 #define REQ_INFO_GIT_HASH 0x0
+#define REQ_BOOT 0xBB
 
 void req_gpio(uint16_t wIndex, uint16_t wValue) {
 	if ( (wIndex & 0xF0) == REQ_PWR_PORT_A_IO 
@@ -351,6 +352,12 @@ void req_info(uint16_t wIndex) {
     return usb_ep0_in(len);
 }
 
+void req_boot() {
+    wdt_reset(GCLK_32K);
+    usb_ep0_out();
+    return usb_ep0_in(0);
+}
+
 void usb_cb_control_setup(void) {
 	uint8_t recipient = usb_setup.bmRequestType & USB_REQTYPE_RECIPIENT_MASK;
 	if (recipient == USB_RECIPIENT_DEVICE) {
@@ -358,6 +365,7 @@ void usb_cb_control_setup(void) {
 			case 0xee:	  return usb_handle_msft_compatible(&msft_compatible);
 			case REQ_PWR: return req_gpio(usb_setup.wIndex, usb_setup.wValue);
 			case REQ_INFO: return req_info(usb_setup.wIndex);
+			case REQ_BOOT: return req_boot();
 		}
 	} else if (recipient == USB_RECIPIENT_INTERFACE) {
 	}

--- a/scripts/boot.py
+++ b/scripts/boot.py
@@ -1,0 +1,10 @@
+import sys
+import usb.core
+
+REQ_BOOT  = 0xbb
+
+dev = usb.core.find(idVendor=0x9999, idProduct=0xffff)
+if dev is None:
+    raise ValueError('device is not connected')
+
+dev.ctrl_transfer(0x40, REQ_BOOT, 0, 0, '')


### PR DESCRIPTION
Abuse the WDT as a delayed reset source that sets a telltale bit in
RCAUSE. Add a vendor request to trigger a WDT reset.