### PR TITLE
Enforce jshint rules: passing (Order: 1)

### DIFF
--- a/node/tessel.js
+++ b/node/tessel.js
@@ -21,7 +21,7 @@ function Tessel() {
         new LED('amber', '/sys/devices/leds/leds/tessel:amber:wlan/brightness'),
         new LED('green', '/sys/devices/leds/leds/tessel:green:user1/brightness'),
         new LED('blue', '/sys/devices/leds/leds/tessel:blue:user2/brightness')
-    ]
+    ];
 
     // tessel v1 does not have this version number
     // this is useful for libraries to adapt to changes
@@ -38,21 +38,21 @@ function Port(name, socketPath, board) {
     });
 
     this.sock.on('error', function(e) {
-        console.log('sock err', e)
-    })
+        console.log('sock err', e);
+    });
 
     this.sock.on('close', function() {
         throw new Error("Port socket closed");
-    })
+    });
 
     var replyBuf = new Buffer(0);
 
     this.sock.on('readable', function() {
-        replyBuf = Buffer.concat([replyBuf, this.sock.read()])
+        replyBuf = Buffer.concat([replyBuf, this.sock.read()]);
 
-        while (replyBuf.length != 0) {
+        while (replyBuf.length !== 0) {
             var byte = replyBuf[0];
-            if (byte == REPLY.ASYNC_UART_RX) {
+            if (byte === REPLY.ASYNC_UART_RX) {
                 // get the next byte which is the number of bytes
                 var rxNum = replyBuf[1];
 
@@ -72,7 +72,7 @@ function Port(name, socketPath, board) {
                     var pin = this.pin[byte - REPLY.ASYNC_PIN_CHANGE_N];
 
                     var mode = pin.interruptMode;
-                    if (mode == 'low' || mode == 'high') {
+                    if (mode === 'low' || mode === 'high') {
                         pin.interruptMode = null;
                     }
 
@@ -81,13 +81,13 @@ function Port(name, socketPath, board) {
                     this.emit('async-event', byte);
                 }
             } else {
-                if (this.replyQueue.length == 0) {
+                if (this.replyQueue.length === 0) {
                     throw new Error("Received an unexpected response with no commands pending: " + byte);
                 }
 
                 var data_size = this.replyQueue[0].size;
 
-                if (byte == REPLY.DATA) {
+                if (byte === REPLY.DATA) {
                     if (!data_size) {
                         throw new Error("Received unexpected data packet");
                     }
@@ -116,8 +116,8 @@ function Port(name, socketPath, board) {
 
     this.pin = [];
     for (var i=0; i<8; i++) {
-        var adcSupported = name == 'B' || [4, 7].indexOf(i) != -1 ? true: false;
-        this.pin.push(new Pin(i, this, [2,5,6,7].indexOf(i) != -1, adcSupported));
+        var adcSupported = name === 'B' || [4, 7].indexOf(i) !== -1 ? true: false;
+        this.pin.push(new Pin(i, this, [2,5,6,7].indexOf(i) !== -1, adcSupported));
     }
 
     // Deprecated properties for Tessel 1 backwards compatibility:
@@ -131,30 +131,28 @@ function Port(name, socketPath, board) {
 
 Port.prototype.cork = function() {
     this.sock.cork();
-}
+};
 
 Port.prototype.uncork = function() {
     this.sock.uncork();
-}
+};
 
 Port.prototype.sync = function(cb) {
     if (cb) {
         this.sock.write(new Buffer([CMD.ECHO, 1, 0x88]));
         this.replyQueue.push({
             size: 1,
-            callback: function(err, data) {
-                cb(null);
-            }
+            callback: cb
         });
     }
-}
+};
 
 Port.prototype._simple_cmd = function(buf, cb) {
-    this.cork()
-    this.sock.write(new Buffer(buf))
-    this.sync(cb)
-    this.uncork()
-}
+    this.cork();
+    this.sock.write(new Buffer(buf));
+    this.sync(cb);
+    this.uncork();
+};
 
 Port.prototype._status_cmd = function(buf, cb) {
     this.sock.write(new Buffer(buf));
@@ -162,10 +160,10 @@ Port.prototype._status_cmd = function(buf, cb) {
         size: 0,
         callback: cb,
     });
-}
+};
 
 Port.prototype._tx = function(buf, cb) {
-    if (buf.length == 0) {
+    if (buf.length === 0) {
         throw new Error("Length must be non-zero");
     } else if (buf.length > 255) {
         // TODO: split into sequence of commands
@@ -173,14 +171,14 @@ Port.prototype._tx = function(buf, cb) {
     }
 
     this.cork();
-    this.sock.write(new Buffer([CMD.TX, buf.length]))
+    this.sock.write(new Buffer([CMD.TX, buf.length]));
     this.sock.write(buf);
     this.sync(cb);
     this.uncork();
-}
+};
 
 Port.prototype._rx = function(len, cb) {
-    if (len == 0) {
+    if (len === 0) {
         throw new Error("Length must be non-zero");
     } else if (len > 255) {
         // TODO: split into sequence of commands
@@ -192,10 +190,10 @@ Port.prototype._rx = function(len, cb) {
         size: len,
         callback: cb,
     });
-}
+};
 
 Port.prototype._txrx = function(buf, cb) {
-    if (buf.length == 0) {
+    if (buf.length === 0) {
         throw new Error("Length must be non-zero");
     } else if (buf.length > 255) {
         // TODO: split into sequence of commands
@@ -203,14 +201,14 @@ Port.prototype._txrx = function(buf, cb) {
     }
 
     this.cork();
-    this.sock.write(new Buffer([CMD.TXRX, buf.length]))
+    this.sock.write(new Buffer([CMD.TXRX, buf.length]));
     this.sock.write(buf);
     this.replyQueue.push({
         size: buf.length,
         callback: cb,
     });
     this.uncork();
-}
+};
 
 Port.prototype.I2C = function (addr, mode) {
     if (!this._i2c) {
@@ -221,7 +219,7 @@ Port.prototype.I2C = function (addr, mode) {
 
 Port.prototype.SPI = function (format) {
     if (!this._spi) {
-        this._spi = new SPI(format == null ? {} : format, this);
+        this._spi = new SPI(format === null ? {} : format, this);
     }
     return this._spi;
 };
@@ -254,9 +252,9 @@ Pin.interruptModes = {
 
 Pin.prototype.removeListener = function(event, listener) {
     // If it's an interrupt event, remove as necessary
-    var emitter = Pin.super_.prototype.removeListener.apply(this, arguments);
+    var emitter = Pin.super_.prototype.removeListener.call(this, event, listener);
 
-    if (event == this.interruptMode && EventEmitter.listenerCount(this, event)) {
+    if (event === this.interruptMode && EventEmitter.listenerCount(this, event)) {
         this._setInterruptMode(null);
     }
 
@@ -264,7 +262,7 @@ Pin.prototype.removeListener = function(event, listener) {
 };
 
 Pin.prototype.removeAllListeners = function(event) {
-    if (!event || event == this.interruptMode) {
+    if (!event || event === this.interruptMode) {
         this._setInterruptMode(null);
     }
 
@@ -274,17 +272,17 @@ Pin.prototype.removeAllListeners = function(event) {
 Pin.prototype.addListener = function(mode, callback) {
     if (mode in Pin.interruptModes) {
         if (!this.interruptSupported) {
-            throw new Error("Interrupts are not supported on pin " + this.pin)
+            throw new Error("Interrupts are not supported on pin " + this.pin);
         }
 
-        if ((mode == 'high' || mode == 'low') && !callback.listener) {
+        if ((mode === 'high' || mode === 'low') && !callback.listener) {
             throw new Error("Cannot use 'on' with level interrupts. You can only use 'once'.");
         }
 
-        if (this.interruptMode != mode) {
+        if (this.interruptMode !== mode) {
             if (this.interruptMode) {
-                throw new Error("Can't set pin interrupt mode to " + mode
-                                + "; already listening for " + this.interruptMode);
+                throw new Error("Can't set pin interrupt mode to " + mode +
+                                "; already listening for " + this.interruptMode);
             }
             this._setInterruptMode(mode);
         }
@@ -304,12 +302,12 @@ Pin.prototype._setInterruptMode = function(mode) {
 Pin.prototype.high = function(cb) {
     this._port._simple_cmd([CMD.GPIO_HIGH, this.pin], cb);
     return this;
-}
+};
 
 Pin.prototype.low = function(cb) {
     this._port._simple_cmd([CMD.GPIO_LOW, this.pin], cb);
     return this;
-}
+};
 
 // Deprecated. Added for tessel 1 lib compat
 Pin.prototype.rawWrite = function(value){
@@ -319,12 +317,12 @@ Pin.prototype.rawWrite = function(value){
         this.low();
     }
     return this;
-}
+};
 
 Pin.prototype.toggle = function(cb) {
     this._port._simple_cmd([CMD.GPIO_TOGGLE, this.pin], cb);
     return this;
-}
+};
 
 Pin.prototype.output = function output(initialValue, cb) {
     if (initialValue) {
@@ -333,31 +331,31 @@ Pin.prototype.output = function output(initialValue, cb) {
         this.low(cb);
     }
     return this;
-}
+};
 
 Pin.prototype.write = function (value, cb) {
     // same as .output
     return this.output(value, cb);
 };
 
-Pin.prototype.rawDirection = function (isOutput, cb) {
+Pin.prototype.rawDirection = function () {
     throw new Error("Pin.rawDirection is deprecated. Use Pin.input or .output instead.");
 };
 
 Pin.prototype._readPin = function (cmd, cb){
     this._port.cork();
-    this._port.sock.write(new Buffer([cmd, this.pin]))
+    this._port.sock.write(new Buffer([cmd, this.pin]));
     this._port.replyQueue.push({
         size: 0,
         callback: function(err, data){
-            cb(err, data == REPLY.HIGH ? 1 : 0);
+            cb(err, data === REPLY.HIGH ? 1 : 0);
         },
     });
     this._port.uncork();
-}
+};
 
 Pin.prototype.rawRead = function rawRead(cb) {
-    if (typeof cb != "function") {
+    if (typeof cb !== "function") {
         console.warn("pin.rawRead is async, pass in a callback to get the value");
     }
     this._readPin(CMD.GPIO_RAW_READ, cb);
@@ -370,16 +368,16 @@ Pin.prototype.input = function input(cb) {
 };
 
 Pin.prototype.read = function (cb) {
-    if (typeof cb != "function") {
+    if (typeof cb !== "function") {
         console.warn("pin.read is async, pass in a callback to get the value");
     }
     this._readPin(CMD.GPIO_IN, cb);
   return this;
 };
 
-Pin.prototype.readPulse = function(type, timeout, callback) {
+Pin.prototype.readPulse = function(/* type, timeout, callback */) {
     throw new Error("Pin.readPulse is not yet implemented");
-}
+};
 
 var ANALOG_RESOLUTION = 4096;
 Pin.prototype.resolution = ANALOG_RESOLUTION;
@@ -390,11 +388,11 @@ Pin.prototype.analogRead = function (cb) {
         return this;
     }
 
-    if (typeof cb != "function") {
+    if (typeof cb !== "function") {
         console.warn("analogPin.read is async, pass in a callback to get the value");
     }
 
-    this._port.sock.write(new Buffer([CMD.ANALOG_READ, this.pin]))
+    this._port.sock.write(new Buffer([CMD.ANALOG_READ, this.pin]));
     this._port.replyQueue.push({
         size: 2,
         callback: function(err, data){
@@ -403,11 +401,11 @@ Pin.prototype.analogRead = function (cb) {
     });
 
     return this;
-}
+};
 
 Pin.prototype.analogWrite = function (val) {
     // throw an error if this isn't the adc pin (port b, pin 7)
-    if (this._port.name != 'B' || this.pin != 7) {
+    if (this._port.name !== 'B' || this.pin !== 7) {
         throw new Error("Analog write can only be used on Pin 7 (G3) of Port B.");
     }
 
@@ -419,7 +417,7 @@ Pin.prototype.analogWrite = function (val) {
 
     this._port.sock.write(new Buffer([CMD.ANALOG_WRITE, data >> 8, data & 0xff]));
     return this;
-}
+};
 
 function I2C(params, port) {
     this.addr = params.addr;
@@ -443,7 +441,7 @@ I2C.prototype.send = function(data, callback) {
     this._port._tx(data);
     this._port._simple_cmd([CMD.STOP], callback);
     this._port.uncork();
-}
+};
 
 I2C.prototype.read = function(length, callback) {
     this._port.cork();
@@ -451,7 +449,7 @@ I2C.prototype.read = function(length, callback) {
     this._port._rx(length, callback);
     this._port._simple_cmd([CMD.STOP]);
     this._port.uncork();
-}
+};
 
 I2C.prototype.transfer = function(txbuf, rxlen, callback) {
     this._port.cork();
@@ -463,14 +461,14 @@ I2C.prototype.transfer = function(txbuf, rxlen, callback) {
     this._port._rx(rxlen, callback);
     this._port._simple_cmd([CMD.STOP]);
     this._port.uncork();
-}
+};
 
 function SPI(params, port) {
     this._port = port;
     // default to pin 5 of the module port as cs
     this.chipSelect = params.chipSelect || this._port.digital[0];
 
-    this.chipSelectActive = params.chipSelectActive == 'high' || params.chipSelectActive == 1 ? 1 : 0;
+    this.chipSelectActive = params.chipSelectActive === 'high' || params.chipSelectActive === 1 ? 1 : 0;
 
     if (this.chipSelectActive) {
         // active high, pull low for now
@@ -512,13 +510,13 @@ function SPI(params, port) {
         this._clockDiv = 1;
     }
 
-    if (typeof params.dataMode == 'number') {
+    if (typeof params.dataMode === 'number') {
         params.cpol = params.dataMode & 0x1;
         params.cpha = params.dataMode & 0x2;
     }
 
-    this.cpol = params.cpol == 'high' || params.cpol == 1 ? 1 : 0;
-    this.cpha = params.cpha == 'second' || params.cpha == 1 ? 1 : 0;
+    this.cpol = params.cpol === 'high' || params.cpol === 1 ? 1 : 0;
+    this.cpha = params.cpha === 'second' || params.cpha === 1 ? 1 : 0;
 
     this._port._simple_cmd([CMD.ENABLE_SPI, this.cpol + (this.cpha << 1), this.clockReg, this._clockDiv]);
 }
@@ -529,11 +527,11 @@ SPI.prototype.send = function(data, callback) {
     this._port._tx(data, callback);
     this.chipSelect.high();
     this._port.uncork();
-}
+};
 
 SPI.prototype.deinit = function(){
     this._port._simple_cmd([CMD.CMD_DISABLE_SPI]);
-}
+};
 
 SPI.prototype.receive = function(data_len, callback) {
     this._port.cork();
@@ -541,7 +539,7 @@ SPI.prototype.receive = function(data_len, callback) {
     this._port._rx(data_len, callback);
     this.chipSelect.high();
     this._port.uncork();
-}
+};
 
 SPI.prototype.transfer = function(data, callback) {
     this._port.cork();
@@ -549,7 +547,7 @@ SPI.prototype.transfer = function(data, callback) {
     this._port._txrx(data, callback);
     this.chipSelect.high();
     this._port.uncork();
-}
+};
 
 function UART(port, options) {
     Duplex.call(this, {});
@@ -581,14 +579,14 @@ UART.prototype._write = function(chunk, encoding, cb) {
         throw new Error("UART is not enabled on this port");
     }
     this._port._tx(chunk, cb);
-}
+};
 
-UART.prototype._read = function() {}
+UART.prototype._read = function() {};
 
 UART.prototype.disable = function() {
     this._port._simple_cmd([CMD.DISABLE_UART, 0, 0]);
     this.enabled = false;
-}
+};
 
 var CMD = {
     NOP: 0,
@@ -630,10 +628,11 @@ var REPLY = {
     ASYNC_UART_RX: 0xD0
 };
 
-var SPISettings = {
-    CPOL: 1,
-    CPHA: 2
-};
+// Currently unused. Uncomment when ready to implement
+// var SPISettings = {
+//   CPOL: 1,
+//   CPHA: 2
+// };
 
 function LED(color, path) {
     this.color = color;
@@ -642,15 +641,15 @@ function LED(color, path) {
 
 LED.prototype.high = function(callback) {
     this.write(true, callback);
-}
+};
 
 LED.prototype.low = function(callback) {
     this.write(false, callback);
-}
+};
 
 LED.prototype.output = function(value, callback) {
     this.write(value, callback);
-}
+};
 
 LED.prototype.toggle = function(callback) {
     var self = this;
@@ -664,12 +663,12 @@ LED.prototype.toggle = function(callback) {
         else {
             self.write(!value, callback);
         }
-    })
-}
+    });
+};
 
 LED.prototype.write = function(value, callback) {
     fs.writeFile(this._path, value ? '1' : '0', callback);
-}
+};
 
 LED.prototype.read = function(callback) {
     fs.readFile(this._path, function(err, value) {
@@ -684,17 +683,17 @@ LED.prototype.read = function(callback) {
             value = value.toString().trim();
             if (value === '1') {
                 callback(null, true);
-                return
+                return;
             }
             else if (value === '0') {
                 callback(null, false);
-                return
+                return;
             }
             else {
                 throw new Error("Invalid state returned by LED:" + value);
             }
         }
-    })
-}
+    });
+};
 
 module.exports = new Tessel();


### PR DESCRIPTION
Fixes:

```
 tessel.js
     24 |    ]
              ^ Missing semicolon.
     41 |        console.log('sock err', e)
                                           ^ Missing semicolon.
     42 |    })
               ^ Missing semicolon.
     46 |    })
               ^ Missing semicolon.
     51 |        replyBuf = Buffer.concat([replyBuf, this.sock.read()])
                                                                       ^ Missing semicolon.
     53 |        while (replyBuf.length != 0) {
                                          ^ Expected '!==' and instead saw '!='.
     55 |            if (byte == REPLY.ASYNC_UART_RX) {
                                ^ Expected '===' and instead saw '=='.
     75 |                    if (mode == 'low' || mode == 'high') {
                                        ^ Expected '===' and instead saw '=='.
     75 |                    if (mode == 'low' || mode == 'high') {
                                                         ^ Expected '===' and instead saw '=='.
     84 |                if (this.replyQueue.length == 0) {
                                                      ^ Expected '===' and instead saw '=='.
     90 |                if (byte == REPLY.DATA) {
                                    ^ Expected '===' and instead saw '=='.
    119 |        var adcSupported = name == 'B' || [4, 7].indexOf(i) != -1 ? true: false;
                                           ^ Expected '===' and instead saw '=='.
    119 |        var adcSupported = name == 'B' || [4, 7].indexOf(i) != -1 ? true: false;
                                                                       ^ Expected '!==' and instead saw '!='.
    120 |        this.pin.push(new Pin(i, this, [2,5,6,7].indexOf(i) != -1, adcSupported));
                                                                       ^ Expected '!==' and instead saw '!='.
    134 |}
          ^ Missing semicolon.
    138 |}
          ^ Missing semicolon.
    150 |}
          ^ Missing semicolon.
    153 |    this.cork()
                        ^ Missing semicolon.
    154 |    this.sock.write(new Buffer(buf))
                                             ^ Missing semicolon.
    155 |    this.sync(cb)
                          ^ Missing semicolon.
    156 |    this.uncork()
                          ^ Missing semicolon.
    157 |}
          ^ Missing semicolon.
    165 |}
          ^ Missing semicolon.
    168 |    if (buf.length == 0) {
                              ^ Expected '===' and instead saw '=='.
    176 |    this.sock.write(new Buffer([CMD.TX, buf.length]))
                                                              ^ Missing semicolon.
    180 |}
          ^ Missing semicolon.
    183 |    if (len == 0) {
                       ^ Expected '===' and instead saw '=='.
    195 |}
          ^ Missing semicolon.
    198 |    if (buf.length == 0) {
                              ^ Expected '===' and instead saw '=='.
    206 |    this.sock.write(new Buffer([CMD.TXRX, buf.length]))
                                                                ^ Missing semicolon.
    213 |}
          ^ Missing semicolon.
    259 |    if (event == this.interruptMode && EventEmitter.listenerCount(this, event)) {
                         ^ Expected '===' and instead saw '=='.
    267 |    if (!event || event == this.interruptMode) {
                                   ^ Expected '===' and instead saw '=='.
    277 |            throw new Error("Interrupts are not supported on pin " + this.pin)
                                                                                       ^ Missing semicolon.
    280 |        if ((mode == 'high' || mode == 'low') && !callback.listener) {
                             ^ Expected '===' and instead saw '=='.
    280 |        if ((mode == 'high' || mode == 'low') && !callback.listener) {
                                               ^ Expected '===' and instead saw '=='.
    284 |        if (this.interruptMode != mode) {
                                          ^ Expected '!==' and instead saw '!='.
    287 |                                + "; already listening for " + this.interruptMode);
                                         ^ Bad line breaking before '+'.
    307 |}
          ^ Missing semicolon.
    312 |}
          ^ Missing semicolon.
    322 |}
          ^ Missing semicolon.
    327 |}
          ^ Missing semicolon.
    336 |}
          ^ Missing semicolon.
    349 |    this._port.sock.write(new Buffer([cmd, this.pin]))
                                                               ^ Missing semicolon.
    353 |            cb(err, data == REPLY.HIGH ? 1 : 0);
                                    ^ Expected '===' and instead saw '=='.
    357 |}
          ^ Missing semicolon.
    360 |    if (typeof cb != "function") {
                             ^ Expected '!==' and instead saw '!='.
    373 |    if (typeof cb != "function") {
                             ^ Expected '!==' and instead saw '!='.
    382 |}
          ^ Missing semicolon.
    393 |    if (typeof cb != "function") {
                             ^ Expected '!==' and instead saw '!='.
    397 |    this._port.sock.write(new Buffer([CMD.ANALOG_READ, this.pin]))
                                                                           ^ Missing semicolon.
    406 |}
          ^ Missing semicolon.
    422 |}
          ^ Missing semicolon.
    446 |}
          ^ Missing semicolon.
    454 |}
          ^ Missing semicolon.
    466 |}
          ^ Missing semicolon.
    532 |}
          ^ Missing semicolon.
    536 |}
          ^ Missing semicolon.
    544 |}
          ^ Missing semicolon.
    552 |}
          ^ Missing semicolon.
    584 |}
          ^ Missing semicolon.
    586 |UART.prototype._read = function() {}
                                             ^ Missing semicolon.
    591 |}
          ^ Missing semicolon.
    645 |}
          ^ Missing semicolon.
    649 |}
          ^ Missing semicolon.
    653 |}
          ^ Missing semicolon.
    667 |    })
               ^ Missing semicolon.
    668 |}
          ^ Missing semicolon.
    672 |}
          ^ Missing semicolon.
    687 |                return
                               ^ Missing semicolon.
    691 |                return
                               ^ Missing semicolon.
    697 |    })
               ^ Missing semicolon.
    698 |}
          ^ Missing semicolon.
    633 |var SPISettings = {
             ^ 'SPISettings' is defined but never used.
    145 |            callback: function(err, data) {
                                             ^ 'data' is defined but never used.
    145 |            callback: function(err, data) {
                                        ^ 'err' is defined but never used.
    255 |Pin.prototype.removeListener = function(event, listener) {
                                                        ^ 'listener' is defined but never used.
    343 |Pin.prototype.rawDirection = function (isOutput, cb) {
                                                          ^ 'cb' is defined but never used.
    343 |Pin.prototype.rawDirection = function (isOutput, cb) {
                                                ^ 'isOutput' is defined but never used.
    380 |Pin.prototype.readPulse = function(type, timeout, callback) {
                                                           ^ 'callback' is defined but never used.
    380 |Pin.prototype.readPulse = function(type, timeout, callback) {
                                                  ^ 'timeout' is defined but never used.
    380 |Pin.prototype.readPulse = function(type, timeout, callback) {
                                            ^ 'type' is defined but never used.
```