### PR TITLE
Make Port a subclass of EventEmitter. Fixes gh-65

### DIFF
--- a/node/tessel.js
+++ b/node/tessel.js
@@ -80,8 +80,8 @@ Tessel.Port = function(name, socketPath, board) {
       } else if (byte >= REPLY.MIN_ASYNC) {
         if (byte >= REPLY.ASYNC_PIN_CHANGE_N && byte < REPLY.ASYNC_PIN_CHANGE_N + 8) {
           var pin = this.pin[byte - REPLY.ASYNC_PIN_CHANGE_N];
-
           var mode = pin.interruptMode;
+
           if (mode === 'low' || mode === 'high') {
             pin.interruptMode = null;
           }
@@ -175,6 +175,8 @@ Tessel.Port = function(name, socketPath, board) {
     return port._uart;
   };
 };
+
+util.inherits(Tessel.Port, EventEmitter);
 
 Tessel.Port.prototype.cork = function() {
   this.sock.cork();

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -119,6 +119,16 @@ exports['Tessel.Port'] = {
     done();
   },
 
+  emitter: function(test) {
+    test.expect(1);
+
+    var port = new Tessel.Port('foo', '/foo/bar/baz', this.tessel);
+
+    test.ok(port instanceof EventEmitter);
+
+    test.done();
+  },
+
   instanceProperties: function(test) {
     test.expect(14);
 
@@ -580,22 +590,18 @@ exports['Tessel.Port Commands (handling incoming socket stream)'] = {
 
     test.done();
   },
-  //
-  //
-  // // According to the 'readable' handler, this should work.
-  // // It currently does not work because Port is not a
-  // // subclass of Emitter.
-  // replyminasync: function(test) {
-  //   test.expect(1);
 
-  //   this.port.once('async-event', function(data) {
-  //     test.equal(data, REPLY.MIN_ASYNC);
-  //     test.done();
-  //   });
+  replyminasync: function(test) {
+    test.expect(1);
 
-  //   this.port.sock.read.returns(new Buffer([REPLY.MIN_ASYNC]));
-  //   this.port.sock.emit('readable');
-  // },
+    this.port.on('async-event', function(data) {
+      test.equal(data, REPLY.MIN_ASYNC);
+      test.done();
+    });
+
+    this.port.sock.read.returns(new Buffer([REPLY.MIN_ASYNC]));
+    this.port.sock.emit('readable');
+  },
 };
 
 exports['Tessel.I2C'] = {

--- a/node/tests/interrupt.js
+++ b/node/tests/interrupt.js
@@ -1,0 +1,15 @@
+var tessel = require('tessel');
+var portA = tessel.port.A;
+var portB = tessel.port.B;
+
+[2, 5, 6, 7].forEach(function(index) {
+  portA.pin[index].low();
+  portA.pin[index].once('high', function() {
+    console.log('(A) Pin: %d went high!', index);
+  });
+
+  portB.pin[index].low();
+  portB.pin[index].once('high', function() {
+    console.log('(B) Pin: %d went high!', index);
+  });
+});


### PR DESCRIPTION
Blocked by #64 

Once #64 lands, I will rebase this branch to prepare for merging. 

Smoke tests completed: 

- interrupts on port A pins 2, 5, 6, 7
- interrupts on port B pins 2, 5, 6, 7

The only changes relevant to this specific issue are https://github.com/rwaldron/t2-firmware/commit/0368d980ef33f53163692041bde67e16701b0a67