### PR TITLE
Set OpenWRT default pixel value 255 to be logically false

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -763,6 +763,8 @@ Tessel.LED.prototype.read = function(callback) {
       } else if (value === '0') {
         callback(null, false);
         return;
+      } else if (value === '255') {
+        callback(null, false);
       } else {
         throw new Error('Invalid state returned by LED:' + value);
       }

--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -619,7 +619,7 @@ Tessel.SPI.prototype.receive = function(data_len, callback) {
   this._port.uncork();
 };
 
-Tessel.SPI.prototype.transfer = function(data, callback) {
+Tessel.SPI.prototype.transfer = function(data, callback) {''
   this._port.cork();
   this.chipSelect.low();
   this._port._txrx(data, callback);
@@ -759,11 +759,7 @@ Tessel.LED.prototype.read = function(callback) {
       value = value.toString().trim();
       if (value === '1') {
         callback(null, true);
-        return;
-      } else if (value === '0') {
-        callback(null, false);
-        return;
-      } else if (value === '255') {
+      } else if (value === '0' || value === '255') {
         callback(null, false);
       } else {
         throw new Error('Invalid state returned by LED:' + value);


### PR DESCRIPTION
Fixes #95 
It appears OpenWRT sets the default pixel value to 255 to mean "off". This change just catches that initial behaviour to match '0' being off.