### PR TITLE
[WIP] Legit boot state LEDs

### DIFF
--- a/common/hw.h
+++ b/common/hw.h
@@ -237,6 +237,12 @@ void tcc_delay_start(TimerId id, u32 ticks);
 void tcc_delay_disable(TimerId id);
 void tcc_delay_enable(TimerId id);
 
+
+void tc_delay_start(TimerId id, u32 ticks);
+void tc_delay_disable(TimerId id);
+void tc_delay_enable(TimerId id);
+void tc_clear_interrupt_flag(TimerId id);
+
 // wdt
 
 inline static void wdt_reset(u32 clock_channel) {

--- a/common/timer.c
+++ b/common/timer.c
@@ -42,6 +42,8 @@ void tc_delay_start(TimerId id, u32 ticks) {
     // Set the top of the counter
     tc(id)->COUNT16.CC[0].reg = ticks;
 
+    NVIC_EnableIRQ(TC3_IRQn + (id - 3));
+
     // Enable the counter!
     tc(id)->COUNT16.CTRLA.bit.ENABLE = 1;
 }
@@ -58,13 +60,9 @@ void tc_delay_disable(TimerId id) {
 // setup a new timer/capture delay channel
 void tc_delay_enable(TimerId id) {
     // Set up the timer
-    PM->APBCMASK.reg |= 1 << (PM_APBCMASK_TC3_Pos + id);
+    timer_clock_enable(id);
 
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN |
-        GCLK_CLKCTRL_GEN(0) |
-        GCLK_CLKCTRL_ID(TC3_GCLK_ID + ((id-2)/2));
-
-    // Reset the generation
+    // Reset the timer
     tc(id)->COUNT16.CTRLA.reg |= TC_CTRLA_SWRST;
 
     // Set it to use a 16 bit counter, resync on glock, 1024 clock prescaler, run in standby

--- a/firmware/firmware.h
+++ b/firmware/firmware.h
@@ -35,8 +35,9 @@
 #define USB_EP_CDC_OUT          0x04
 
 /// Timer allocation
-#define TC_TERMINAL_TIMEOUT 3
-#define TC_BOOT             4
+#define TC_TERMINAL_TIMEOUT  3
+#define TC_BOOT              4
+#define TC_BOOTING_ANIMATION 5
 
 // TCC allocation
 // muxed with i2c. also used for uart read timers

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -3,35 +3,6 @@
 PortData port_a;
 PortData port_b;
 
-volatile bool booted = false;
-
-/*** SysTick ***/
-volatile uint32_t g_msTicks;
-
-/* SysTick IRQ handler */
-void SysTick_Handler(void) {
-    g_msTicks++;
-}
-
-void init_systick() {
-    if (SysTick_Config(48000000 / 1000)) {  /* Setup SysTick Timer for 1 msec interrupts  */
-        while (1) {}                                /* Capture error */
-    }
-    NVIC_SetPriority(SysTick_IRQn, 0x0);
-    g_msTicks = 0;
-}
-
-/*** LED ***/
-unsigned led_next_time = 0;
-void led_task() {
-    if (g_msTicks > led_next_time) {
-        led_next_time += 400;
-        pin_toggle(PORT_A.power);
-        pin_toggle(PORT_B.power);
-        pin_toggle(PIN_LED);
-    }
-}
-
 void boot_delay_ms(int delay){
     tc(TC_BOOT)->COUNT16.CTRLA.reg
         = TC_CTRLA_WAVEGEN_MPWM
@@ -135,17 +106,7 @@ int main(void) {
 
     __enable_irq();
 
-    init_systick();
-
-    while (1) {
-        if (booted == false) {
-            led_task();
-        }
-        else {
-
-        }
-        __WFI();
-    }
+    while (1) { __WFI(); }
 }
 
 void DMAC_Handler() {
@@ -205,10 +166,7 @@ void SERCOM_HANDLER(SERCOM_PORT_B_UART_I2C) {
 }
 
 void bridge_open_0() {
-    booted = true;
-    pin_high(PIN_LED);
-    pin_low(PORT_A.power);
-    pin_low(PORT_B.power);
+   tc_delay_disable(TC_BOOTING_ANIMATION);
 }
 void bridge_completion_out_0(u8 count) {
     pipe_bridge_out_completion(count);
@@ -242,6 +200,13 @@ void bridge_completion_in_2() {
 }
 void bridge_close_2() {
     port_disable(&port_b);
+}
+
+void TC_HANDLER(TC_BOOTING_ANIMATION) {
+    // Toggle the pin (I know it says high right now... I'm testing)
+    pin_high(PORT_A.power);
+    // Clear the interrupt flag
+    tc_clear_interrupt_flag(TC_BOOTING_ANIMATION);
 }
 
 void TC_HANDLER(TC_TERMINAL_TIMEOUT) {

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -106,6 +106,9 @@ int main(void) {
 
     __enable_irq();
 
+    tc_delay_enable(TC_BOOTING_ANIMATION);
+    tc_delay_start(TC_BOOTING_ANIMATION, 10000);
+
     while (1) { __WFI(); }
 }
 
@@ -166,7 +169,10 @@ void SERCOM_HANDLER(SERCOM_PORT_B_UART_I2C) {
 }
 
 void bridge_open_0() {
-   tc_delay_disable(TC_BOOTING_ANIMATION);
+    // disable the animation timer
+    tc_delay_disable(TC_BOOTING_ANIMATION);
+    // Pull the port pin low
+    pin_low(PORT_A.power);
 }
 void bridge_completion_out_0(u8 count) {
     pipe_bridge_out_completion(count);
@@ -204,7 +210,7 @@ void bridge_close_2() {
 
 void TC_HANDLER(TC_BOOTING_ANIMATION) {
     // Toggle the pin (I know it says high right now... I'm testing)
-    pin_high(PORT_A.power);
+    pin_toggle(PORT_A.power);
     // Clear the interrupt flag
     tc_clear_interrupt_flag(TC_BOOTING_ANIMATION);
 }


### PR DESCRIPTION
Most of this code was just copied straight from the [booloader's main.c](https://github.com/tessel/t2-firmware/blob/master/boot/main.c) since it already has blinking LED code. Yes, I am ashamed. 

In the future, this should use the Timer Control feature and the `bridge_open_0` IRQ should disable the TC.

To test:
- put T2 into bootloader mode by plugging it in while holding down the button
- run `make` on this branch
- run `dfu-util -aFlash -l -D build/firmware.bin` in your terminal
- watch the blinking lights.