### PR TITLE
Fixes to reset USB Daemon state reliably

### DIFF
--- a/boot.mk
+++ b/boot.mk
@@ -11,5 +11,5 @@ $(TARGET)_SRC += \
   boot/usb.c \
   $(USB_PATH)/class/dfu/dfu.c
 
-$(TARGET)_LDSCRIPT = deps/sam0/linker_scripts/samd21/gcc/samd21g15a_flash.ld
-$(TARGET)_DEFINE += -D __SAMD21G15A__
+$(TARGET)_LDSCRIPT = deps/sam0/linker_scripts/samd21/gcc/samd21g18a_flash.ld
+$(TARGET)_DEFINE += -D __SAMD21G18A__

--- a/common/samd21g18a_firmware_partition.ld
+++ b/common/samd21g18a_firmware_partition.ld
@@ -49,7 +49,7 @@ SEARCH_DIR(.)
 /* Memory Spaces Definitions */
 MEMORY
 {
-  rom    (rx)  : ORIGIN = 0x00001000, LENGTH = 0x00008000
+  rom    (rx)  : ORIGIN = 0x00001000, LENGTH = 0x0003efff
   ram    (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00001000
 }
 

--- a/firmware.mk
+++ b/firmware.mk
@@ -12,5 +12,5 @@ $(TARGET)_SRC += \
   firmware/usbpipe.c \
   firmware/usbserial.c \
 
-$(TARGET)_LDSCRIPT = common/samd21g15a_firmware_partition.ld
-$(TARGET)_DEFINE += -D __SAMD21G15A__
+$(TARGET)_LDSCRIPT = common/samd21g18a_firmware_partition.ld
+$(TARGET)_DEFINE += -D __SAMD21G18A__

--- a/firmware/bridge.c
+++ b/firmware/bridge.c
@@ -181,8 +181,6 @@ void bridge_dma_rx_completion() {
         #define CHECK_CLOSE(x) \
             if (!(ctrl_rx.status & (0x10<<x)) && (was_open & (0x10<<x))) { \
                 bridge_close_##x(ctrl_rx.size[x]); \
-                out_chan_ready &= ~ (1<<x); \
-                in_chan_size[x] = 0; \
             }
 
         CHECK_OPEN(0)

--- a/firmware/usbpipe.c
+++ b/firmware/usbpipe.c
@@ -1,6 +1,13 @@
 #include "firmware.h"
-
-#define FLASH_BUFFER_SIZE 64
+#define OUT_RING_SIZE 10
+#define PACKET_SIZE 64
+u8 out_ring_buf[OUT_RING_SIZE][PACKET_SIZE];
+volatile u8 out_ring_count = 0; // Number of packets in the ring buffer
+volatile u8 out_ring_write_pos = 0; // Packet index in which we're currently receiving a packet, or will once it's free
+volatile u8 out_ring_read_pos = 0; // Packet index from which we're currently sending a packet, or will once it's filled.
+volatile u8 out_ring_short_packet = 0; // If nonzero, the ring ends with a short packet of this size
+volatile bool out_usb_pending = false;
+volatile bool out_bridge_pending = false;
 
 typedef enum {
     PIPE_DISABLE,
@@ -8,20 +15,19 @@ typedef enum {
     PIPE_WAIT_FOR_BRIDGE,
 } PipeState;
 
-PipeState pipe_state_pc_to_soc;
 PipeState pipe_state_soc_to_pc;
-USB_ALIGN u8 pipe_buffer_pc_to_soc[BRIDGE_BUF_SIZE];
 USB_ALIGN u8 pipe_buffer_soc_to_pc[BRIDGE_BUF_SIZE];
 
 void usbpipe_init() {
     usb_enable_ep(USB_EP_PIPE_OUT, USB_EP_TYPE_BULK, 64);
     usb_enable_ep(USB_EP_PIPE_IN, USB_EP_TYPE_BULK, 64);
 
-    usb_ep_start_out(USB_EP_PIPE_OUT, pipe_buffer_pc_to_soc, FLASH_BUFFER_SIZE);
-    pipe_state_pc_to_soc = PIPE_WAIT_FOR_USB;
+    usb_ep_start_out(USB_EP_PIPE_OUT, out_ring_buf[out_ring_write_pos], PACKET_SIZE);
+    out_usb_pending = true;
+    out_bridge_pending = false;
 
     bridge_start_out(BRIDGE_USB, pipe_buffer_soc_to_pc);
-    pipe_state_soc_to_pc  = PIPE_WAIT_FOR_BRIDGE;
+    pipe_state_soc_to_pc = PIPE_WAIT_FOR_BRIDGE;
 
     bridge_enable_chan(BRIDGE_USB); // Tells SPI Daemon to start connection to USB Daemon
 }
@@ -29,31 +35,69 @@ void usbpipe_init() {
 void usbpipe_disable() {
     usb_disable_ep(USB_EP_PIPE_IN);
     usb_disable_ep(USB_EP_PIPE_OUT);
-    pipe_state_pc_to_soc = PIPE_DISABLE;
+    out_ring_count = 0;
+    out_ring_write_pos = 0;
+    out_ring_read_pos = 0;
+    out_ring_short_packet = 0;
     pipe_state_soc_to_pc = PIPE_DISABLE;
     bridge_disable_chan(BRIDGE_USB); // Tells SPI Daemon to close connection to USB Daemon
 }
 
-// Received from USB, send to bridge
-void pipe_usb_out_completion() {
-    if (pipe_state_pc_to_soc == PIPE_WAIT_FOR_USB) {
-        u32 len = usb_ep_out_length(USB_EP_PIPE_OUT);
-        bridge_start_in(BRIDGE_USB, pipe_buffer_pc_to_soc, len);
-        pipe_state_pc_to_soc = PIPE_WAIT_FOR_BRIDGE;
-    } else {
-        invalid();
+void out_ring_step() {
+    // If we are not currently receiving
+    // And there is an empty buffer to receive data into
+    // And there isn't an unprocessed short packet
+    if (!out_usb_pending && out_ring_count < OUT_RING_SIZE && out_ring_short_packet == 0) {
+        // Start reading data in over USB to the buffer at the correct position (up to 64 bytes)
+        usb_ep_start_out(USB_EP_PIPE_OUT, out_ring_buf[out_ring_write_pos], PACKET_SIZE);
+        // We are waiting for the transfer to complete
+        out_usb_pending = true;
     }
 
+    // If we are not waiting on a bridge transaction to complete and we have packets to send
+    if (!out_bridge_pending && out_ring_count > 0) {
+        // The size of the packet is 64 bytes (unless the below case is true)
+        u8 len = PACKET_SIZE;
+        // If we only have one outgoing packet and it is a short packet
+        if (out_ring_count == 1 && out_ring_short_packet != 0) {
+             // The length is actually a subset of a full packet
+             len = out_ring_short_packet;
+             // Reset the short packet var
+             out_ring_short_packet = 0;
+        }
+        // Start sending data to the spi daemon
+        bridge_start_in(BRIDGE_USB, out_ring_buf[out_ring_read_pos], len);
+        // We are currently waiting on the SPI
+        out_bridge_pending = true;
+    }
+}
+
+// Received from USB, send to bridge
+void pipe_usb_out_completion() {
+    // Get the length of the packet from USB
+    u32 len = usb_ep_out_length(USB_EP_PIPE_OUT);
+    // If it is less than one full packet, mark the short packet var with the length
+    if (len < PACKET_SIZE) out_ring_short_packet = len;
+    // Increase the next writable buffer by 1 (but loop to the beginning if necessary)
+    out_ring_write_pos = (out_ring_write_pos + 1) % OUT_RING_SIZE;
+    // Mark that we have one packet that needs attention
+    out_ring_count += 1;
+    // We are no longer operating over USB
+    out_usb_pending = false;
+    // Push the data to the correct place
+    out_ring_step();
 }
 
 // Finished sending on bridge, start receive from USB
 void pipe_bridge_in_completion() {
-    if (pipe_state_pc_to_soc == PIPE_WAIT_FOR_BRIDGE) {
-        usb_ep_start_out(USB_EP_PIPE_OUT, pipe_buffer_pc_to_soc, FLASH_BUFFER_SIZE);
-        pipe_state_pc_to_soc = PIPE_WAIT_FOR_USB;
-    } else {
-        invalid();
-    }
+    // Increment the location of where we will read from next (to send over USB)
+    out_ring_read_pos = (out_ring_read_pos + 1) % OUT_RING_SIZE;
+    // Decrement the number of packets that need reading
+    out_ring_count -= 1;
+    // Mark the bridge transfer as complete
+    out_bridge_pending = false;
+    // Move data along
+    out_ring_step();
 }
 
 // Received from bridge, send to USB

--- a/firmware/usbpipe.c
+++ b/firmware/usbpipe.c
@@ -23,7 +23,7 @@ void usbpipe_init() {
     bridge_start_out(BRIDGE_USB, pipe_buffer_soc_to_pc);
     pipe_state_soc_to_pc  = PIPE_WAIT_FOR_BRIDGE;
 
-    bridge_enable_chan(BRIDGE_USB); // Tells SPI Daemon to start USB Daemon
+    bridge_enable_chan(BRIDGE_USB); // Tells SPI Daemon to start connection to USB Daemon
 }
 
 void usbpipe_disable() {
@@ -31,7 +31,7 @@ void usbpipe_disable() {
     usb_disable_ep(USB_EP_PIPE_OUT);
     pipe_state_pc_to_soc = PIPE_DISABLE;
     pipe_state_soc_to_pc = PIPE_DISABLE;
-    bridge_disable_chan(BRIDGE_USB); // Tells SPI Daemon to close USB Daemon
+    bridge_disable_chan(BRIDGE_USB); // Tells SPI Daemon to close connection to USB Daemon
 }
 
 // Received from USB, send to bridge

--- a/soc/usbexecd.c
+++ b/soc/usbexecd.c
@@ -42,7 +42,7 @@ enum Commands {
     CMD_CLOSE_STDERR = 0x33,
 };
 
-#define debug(args...)
+#define debug(args...)  syslog(LOG_INFO, args)
 #define info(args...)   syslog(LOG_INFO, args)
 #define error(args...)  syslog(LOG_ERR, args)
 #define fatal(args...) ({ \
@@ -1143,6 +1143,7 @@ int main(int argc, char** argv) {
 
     // Start up a listening socket with a path provided by the user
     initialize_listening_socket(argv[1]);
+
 
     // Create the signal mask for the SIGCHILD and add to epoll
     initialize_sigchild_events();

--- a/soc/usbexecd.c
+++ b/soc/usbexecd.c
@@ -134,6 +134,7 @@ int write_from_pipebuf(pipebuf_t *pb, int fd, int len);
 void pipebuf_out_to_internal_buffer(pipebuf_t* pb, int len);
 void pipebuf_out_is_writable(pipebuf_t* pb);
 void pipebuf_common_debug(pipebuf_t *pb, const char * str);
+void handle_closed_spid_socket();
 
 /* Helper function to write a packet header to the domain socket
 Param: cmd - which command in the Commands enum to send
@@ -446,7 +447,8 @@ void pipebuf_in_ack(pipebuf_t* pb, size_t ack_number_size) {
     // If the socket was closed prematurely
     if (sock_closed == -1) {
         // Return back to the event loop
-        fatal("Remote socket closed in the middle of sending ACK length bytes");
+        debug("Remote socket closed in the middle of sending ACK length bytes");
+        return handle_closed_spid_socket();
     }
 
     int ack_size = 0;
@@ -633,7 +635,8 @@ void pipebuf_out_to_internal_buffer(pipebuf_t* pb, int read_len) {
 
         // If the socket closes, abort
         if (sock_closed == -1) {
-            fatal("Socket connection closed in the middle of ctrl/stdin transmission");
+            debug("Socket connection closed in the middle of ctrl/stdin transmission");
+            return handle_closed_spid_socket();
         }
 
         // Add the number read into the buf count

--- a/test_rig.mk
+++ b/test_rig.mk
@@ -12,5 +12,5 @@ $(TARGET)_SRC += \
   test_rig/pins.c \
   test_rig/button.c \
 
-$(TARGET)_DEFINE += -D __SAMD21J18A__
+$(TARGET)_DEFINE += -D __SAMD21G18A__
 $(TARGET)_LDSCRIPT = common/samd21g18a_firmware_partition.ld

--- a/test_rig.mk
+++ b/test_rig.mk
@@ -13,4 +13,4 @@ $(TARGET)_SRC += \
   test_rig/button.c \
 
 $(TARGET)_DEFINE += -D __SAMD21J18A__
-$(TARGET)_LDSCRIPT = common/samd21g15a_firmware_partition.ld
+$(TARGET)_LDSCRIPT = common/samd21g18a_firmware_partition.ld


### PR DESCRIPTION
Adding this channel disable endpoint essentially lets the CLI reset the state of the USB Daemon each time it's used.

The downside is that we definitely will not be able to have a Tessel being used programmatically by multiple scripts at once over USB because the second one would cancel any ongoing USB comms the first one had going for it.