### PR TITLE
Adds Tessel access point API

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -1542,6 +1542,7 @@ Tessel.AP.prototype.reset = function(callback) {
   }
 
   this.emit('reset', 'Resetting connection');
+  this.emit('off', 'Resetting connection');
   restartWifi()
     .then(() => {
       this.emit('on', this.settings);
@@ -1577,7 +1578,9 @@ Tessel.AP.prototype.create = function(settings, callback) {
     .then(restartWifi)
     .then(getAccessPointIP)
     .then((ip) => {
-      this.settings = Object.assign(settings, {ip});
+      this.settings = Object.assign(settings, {
+        ip
+      });
       this.emit('create', this.settings);
 
       callback(null, this.settings);


### PR DESCRIPTION
A follow-up build to #140, adding a Network Access Point (AP) API. 

TODO:
- [x] tests
- [x] smoke test

===

Proposed API:

**Methods**

- [x] `ap.create(configObject, [callback(err, settings)])`
  - `configObject` contains the following properties: ssid (required), password, security (wpa, psk, psk2, none)
  - default security is 'none', if there is a password in config then default security is 'psk2'
- [X] `ap.enable([callback(err)])`
- [X] `ap.disable([callback(err)])`
- [x] `ap.reset([callback(err)])`


**Events**
Each event contains a settings object. 

- create: access point has been created
- on: access point has been enabled
- off: access point has been disabled
- reset: access point is about to reset
- error: an error occurred

**Concerns:**
Maybe check ap config rather than assuming it pre-exists ([match this logic in t2-cli](https://github.com/tessel/t2-cli/blob/master/lib/tessel/access-point.js#L147-L176)). This was added to t2-cli to support Tessel users who had not yet updated to the latest OpenWRT-Tessel image, which contained the necessary config setup by default. Since this is a firmware upgrade, is this check still necessary? 
