### PR TITLE
Use RangeError where appropriate. Fixes gh-156

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -627,13 +627,13 @@ Tessel.Pin.prototype.analogRead = function(cb) {
 Tessel.Pin.prototype.analogWrite = function(val) {
   // throw an error if this isn't the adc pin (port b, pin 7)
   if (this._port.name !== 'B' || this.pin !== 7) {
-    throw new Error('Analog write can only be used on Pin 7 (G3) of Port B.');
+    throw new RangeError('Analog write can only be used on Pin 7 (G3) of Port B.');
   }
 
   // v_dac = data/(0x3ff)*reference voltage
-  var data = val / (3.3) * 0x3ff;
+  var data = val / 3.3 * 0x3ff;
   if (data > 1023 || data < 0) {
-    throw new Error('Analog write must be between 0 and 3.3');
+    throw new RangeError('Analog write must be between 0 and 3.3');
   }
 
   this._port.sock.write(new Buffer([CMD.ANALOG_WRITE, data >> 8, data & 0xff]));

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -1368,6 +1368,47 @@ exports['Tessel.Pin'] = {
     }, this);
     test.done();
   },
+
+  analogWritePortAndPinRangeError: function(test) {
+    test.expect(16);
+
+    this.a.pin.forEach(pin => {
+      test.throws(() => {
+        pin.analogWrite(1);
+      }, RangeError);
+    });
+
+    this.b.pin.slice(0, -1).forEach(pin => {
+      test.throws(() => {
+        pin.analogWrite(1);
+      }, RangeError);
+    });
+
+    test.doesNotThrow(() => {
+      this.b.pin[7].analogWrite(1);
+    });
+
+    test.done();
+  },
+
+  analogWriteValueRangeError: function(test) {
+    test.expect(3);
+
+    test.throws(() => {
+      this.b.pin[7].analogWrite(-1);
+    }, RangeError);
+
+    test.throws(() => {
+      this.b.pin[7].analogWrite(255);
+    }, RangeError);
+
+    test.throws(() => {
+      this.b.pin[7].analogWrite(3.4);
+    }, RangeError);
+
+    test.done();
+  },
+
 };
 
 exports['Tessel.I2C'] = {


### PR DESCRIPTION
The remaining migrations to RangeError are in the i2c-frequency-range branch

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>