### PR TITLE
fixes https://github.com/tessel/t2-firmware/issues/71

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -554,7 +554,7 @@ Tessel.Pin.prototype.removeAllListeners = function(event) {
 Tessel.Pin.prototype.addListener = function(mode, callback) {
   if (typeof Tessel.Pin.interruptModes[mode] !== 'undefined') {
     if (!this.interruptSupported) {
-      throw new Error('Interrupts are not supported on pin ' + this.pin);
+      throw new Error('Interrupts are not supported on pin ' + this.pin + '. Pins 2, 5, 6, and 7 on either port support interrupts.');
     }
 
     if ((mode === 'high' || mode === 'low') && !callback.listener) {


### PR DESCRIPTION
New more informative error message if you try to call an interrupt on a pin which doesn't support it. Now users receiving this message have something actionable to do.