### PR TITLE
emit 'rise' and 'fall' events along with 'change' event

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -566,7 +566,7 @@ Tessel.Pin.prototype.addListener = function(mode, callback) {
     if (this.interruptMode) {
       var singleEventModes = ['low', 'high'];
       if (singleEventModes.some(value => mode === value || this.interruptMode === value)) {
-        throw new Error(`Cannot set pin interrupt mode to ${mode}; already listening for ${this.interruptMode}. Can only set multiple listeners with change, rise & fall`);
+        throw new Error(`Cannot set pin interrupt mode to "${mode}"; already listening for "${this.interruptMode}". Can only set multiple listeners with "change", "rise" & "fall".`);
       }
     }
 
@@ -577,7 +577,7 @@ Tessel.Pin.prototype.addListener = function(mode, callback) {
     // Add the event listener
     Tessel.Pin.super_.prototype.on.call(this, mode, callback);
   } else {
-    throw new Error(`Invalid pin event mode '${mode}'. Valid modes are 'change', 'rise', 'fall', 'high' and 'low'.`);
+    throw new Error(`Invalid pin event mode "${mode}". Valid modes are "change", "rise", "fall", "high" and "low".`);
   }
 };
 Tessel.Pin.prototype.on = Tessel.Pin.prototype.addListener;

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -1150,7 +1150,7 @@ exports['Tessel.Pin'] = {
     try {
       this.a.pin[0].once('test', spy);
     } catch (error) {
-      test.equal(error.message, "Invalid pin event mode 'test'. Valid modes are 'change', 'rise', 'fall', 'high' and 'low'.");
+      test.equal(error.message, 'Invalid pin event mode "test". Valid modes are "change", "rise", "fall", "high" and "low".');
     }
 
     try {
@@ -1173,7 +1173,7 @@ exports['Tessel.Pin'] = {
       this.a.pin[2].on('rise', spy);
       this.a.pin[2].once('low', spy);
     } catch (error) {
-      test.equal(error.message, 'Cannot set pin interrupt mode to low; already listening for change. Can only set multiple listeners with change, rise & fall');
+      test.equal(error.message, 'Cannot set pin interrupt mode to "low"; already listening for "change". Can only set multiple listeners with "change", "rise" & "fall".');
     }
 
     test.done();
@@ -1280,18 +1280,11 @@ exports['Tessel.Pin'] = {
       test.equal(this.a.pin[pinIndex].interruptMode, 'change');
       test.equal(this.b.pin[pinIndex].interruptMode, 'change');
 
-      // Get the byte for the related pinIndex
-      var byte = REPLY.ASYNC_PIN_CHANGE_N + pinIndex;
-
-      // set pinValue (bit 3) high to simulate a rise
-      var pinValue = 1 << 3;
-      byte |= pinValue;
-
       // Simulate receipt of pin state changes
-      this.a.sock.read.returns(new Buffer([byte]));
+      this.a.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (1 << 3)]));
       this.a.sock.emit('readable');
 
-      this.b.sock.read.returns(new Buffer([byte]));
+      this.b.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (1 << 3)]));
       this.b.sock.emit('readable');
     }, this);
 
@@ -1311,18 +1304,11 @@ exports['Tessel.Pin'] = {
       test.equal(this.a.pin[pinIndex].interruptMode, 'change');
       test.equal(this.b.pin[pinIndex].interruptMode, 'change');
 
-      // Get the byte for the related pinIndex
-      var byte = REPLY.ASYNC_PIN_CHANGE_N + pinIndex;
-
-      // set pinValue (bit 3) low to simulate a fall
-      var pinValue = 0 << 3;
-      byte |= pinValue;
-
       // Simulate receipt of pin state changes
-      this.a.sock.read.returns(new Buffer([byte]));
+      this.a.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (0 << 3)]));
       this.a.sock.emit('readable');
 
-      this.b.sock.read.returns(new Buffer([byte]));
+      this.b.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (0 << 3)]));
       this.b.sock.emit('readable');
     }, this);
 
@@ -1367,10 +1353,10 @@ exports['Tessel.Pin'] = {
       test.equal(this.b.pin[pinIndex].interruptMode, 'change');
 
       // Simulate receipt of pin state changes
-      this.a.sock.read.returns(new Buffer([REPLY.ASYNC_PIN_CHANGE_N + pinIndex]));
+      this.a.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (0 << 3)]));
       this.a.sock.emit('readable');
 
-      this.b.sock.read.returns(new Buffer([REPLY.ASYNC_PIN_CHANGE_N + pinIndex]));
+      this.b.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (0 << 3)]));
       this.b.sock.emit('readable');
     }, this);
 

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -1305,10 +1305,10 @@ exports['Tessel.Pin'] = {
       test.equal(this.b.pin[pinIndex].interruptMode, 'change');
 
       // Simulate receipt of pin state changes
-      this.a.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (0 << 3)]));
+      this.a.sock.read.returns(new Buffer([REPLY.ASYNC_PIN_CHANGE_N + pinIndex]));
       this.a.sock.emit('readable');
 
-      this.b.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (0 << 3)]));
+      this.b.sock.read.returns(new Buffer([REPLY.ASYNC_PIN_CHANGE_N + pinIndex]));
       this.b.sock.emit('readable');
     }, this);
 
@@ -1353,10 +1353,10 @@ exports['Tessel.Pin'] = {
       test.equal(this.b.pin[pinIndex].interruptMode, 'change');
 
       // Simulate receipt of pin state changes
-      this.a.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (0 << 3)]));
+      this.a.sock.read.returns(new Buffer([REPLY.ASYNC_PIN_CHANGE_N + pinIndex]));
       this.a.sock.emit('readable');
 
-      this.b.sock.read.returns(new Buffer([(REPLY.ASYNC_PIN_CHANGE_N + pinIndex) | (0 << 3)]));
+      this.b.sock.read.returns(new Buffer([REPLY.ASYNC_PIN_CHANGE_N + pinIndex]));
       this.b.sock.emit('readable');
     }, this);
 


### PR DESCRIPTION
This allows multiple listeners to be used... `.on('rise')`, `.on('fall')` and `.on('change')` can all be used simultaneously.

See [Issue-69](https://github.com/tessel/t2-firmware/issues/69)