### PR TITLE
Update analog read write range

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -730,12 +730,11 @@ Tessel.Pin.prototype.resolution = ANALOG_RESOLUTION;
 
 Tessel.Pin.prototype.analogRead = function(cb) {
   if (!this.analogSupported) {
-    console.warn('pin.analogRead is not supported on this pin. Analog read is supported on port A pins 4 and 7 and on all pins on port B');
-    return this;
+    throw new RangeError('pin.analogRead is not supported on this pin. Analog read is supported on port A pins 4 and 7 and on all pins on port B');
   }
 
   if (typeof cb !== 'function') {
-    console.warn('analogPin.read is async, pass in a callback to get the value');
+    throw new Error('analogPin.read is async, pass in a callback to get the value');
   }
 
   this._port.sock.write(new Buffer([CMD.ANALOG_READ, this.pin]));

--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -742,7 +742,7 @@ Tessel.Pin.prototype.analogRead = function(cb) {
   this._port.enqueue({
     size: 2,
     callback: function(err, data) {
-      cb(err, (data[0] + (data[1] << 8)) / ANALOG_RESOLUTION * 3.3);
+      cb(err, (data[0] + (data[1] << 8)) / ANALOG_RESOLUTION);
     },
   });
 
@@ -755,10 +755,9 @@ Tessel.Pin.prototype.analogWrite = function(val) {
     throw new RangeError('Analog write can only be used on Pin 7 (G3) of Port B.');
   }
 
-  // v_dac = data/(0x3ff)*reference voltage
-  var data = val / 3.3 * 0x3ff;
-  if (data > 1023 || data < 0) {
-    throw new RangeError('Analog write must be between 0 and 3.3');
+  var data = val * 0x3ff;
+  if (data > 0x3ff || data < 0) {
+    throw new RangeError('Analog write must be between 0 and 1');
   }
 
   this._port.sock.write(new Buffer([CMD.ANALOG_WRITE, data >> 8, data & 0xff]));

--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -730,7 +730,7 @@ Tessel.Pin.prototype.resolution = ANALOG_RESOLUTION;
 
 Tessel.Pin.prototype.analogRead = function(cb) {
   if (!this.analogSupported) {
-    console.warn('pin.analogRead is not supoprted on this pin. Analog read is supported on port A pins 4 and 7 and on all pins on port B');
+    console.warn('pin.analogRead is not supported on this pin. Analog read is supported on port A pins 4 and 7 and on all pins on port B');
     return this;
   }
 

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -1590,7 +1590,15 @@ exports['Tessel.Pin'] = {
   },
 
   analogWriteValueRangeError: function(test) {
-    test.expect(3);
+    test.expect(6);
+
+    test.doesNotThrow(() => {
+      this.b.pin[7].analogWrite(0);
+    }, RangeError);
+
+    test.doesNotThrow(() => {
+      this.b.pin[7].analogWrite(1.0);
+    }, RangeError);
 
     test.throws(() => {
       this.b.pin[7].analogWrite(-1);
@@ -1602,6 +1610,10 @@ exports['Tessel.Pin'] = {
 
     test.throws(() => {
       this.b.pin[7].analogWrite(3.4);
+    }, RangeError);
+
+    test.throws(() => {
+      this.b.pin[7].analogWrite(1.1);
     }, RangeError);
 
     test.done();
@@ -1913,7 +1925,12 @@ exports['Tessel.UART'] = {
     }.bind(this));
 
     // Block creation of automatically generated ports
-    this.tessel = new Tessel({ ports: {'A' : false, 'B' : false} });
+    this.tessel = new Tessel({
+      ports: {
+        'A': false,
+        'B': false
+      }
+    });
 
     this.cork = sandbox.stub(Tessel.Port.prototype, 'cork');
     this.uncork = sandbox.stub(Tessel.Port.prototype, 'uncork');

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -1619,6 +1619,52 @@ exports['Tessel.Pin'] = {
     test.done();
   },
 
+  analogReadPortAndPinRangeWarning: function(test) {
+    test.expect(16);
+
+    var cb = function() {};
+
+    this.a.pin.forEach(pin => {
+      if (pin.pin === 4 || pin.pin === 7) {
+        test.doesNotThrow(() => {
+          pin.analogRead(cb);
+        }, RangeError);
+      } else {
+        test.throws(() => {
+          pin.analogRead(cb);
+        }, RangeError);
+      }
+    });
+
+    this.b.pin.forEach(pin => {
+      test.doesNotThrow(() => {
+        pin.analogRead(cb);
+      }, RangeError);
+    });
+
+    test.done();
+  },
+
+  analogReadAsyncWarning: function(test) {
+    test.expect(10);
+
+    test.throws(() => {
+      this.a.pin[4].analogRead();
+    });
+
+    test.throws(() => {
+      this.a.pin[7].analogRead();
+    });
+
+    this.b.pin.forEach(pin => {
+      test.throws(() => {
+        pin.analogRead();
+      });
+    });
+
+    test.done();
+  },
+
 };
 
 exports['Tessel.I2C'] = {

--- a/node/tests/dac.js
+++ b/node/tests/dac.js
@@ -6,9 +6,9 @@ var val = 0;
 setInterval(function(){
 	console.log("dac =", val);
 	portB.pin[7].analogWrite(val);
-	
-	if (val < 3.2) {
-		val += 0.1;
+
+	if (val < 0.95) {
+		val += 0.05;
 	} else {
 		val = 0;
 	}


### PR DESCRIPTION
See #175.

* Updated `.analogRead()` and `.analogWrite()` to operate on a 0-1 scale.
* Updated tests to account for new range.
* Fixed typo.

I noticed there are no unit tests for `.analogRead()` so maybe we should add some along with this change.

@rwaldron 