### PR TITLE
Wifi.connection(): Fetch network settings, normalize values

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.9",
   "description": "",
   "main": "tessel.js",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
@@ -13,10 +12,11 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jsbeautifier": "^0.2.10",
     "grunt-jscs": "^2.6.0",
+    "npm": "^3.10.5",
     "sinon": "^1.14.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt"
   },
   "author": "Technical Machine <team@technical.io>",
   "license": "MIT"

--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -1418,7 +1418,13 @@ function getWifiInfo() {
                   if (error) {
                     reject(error);
                   } else {
-                    network.ips = ipResults.split('\n');
+                    network.ip = ipResults
+                      .split('\n') // split multiple line string into array of strings
+                      .filter((string) => string.includes('Bcast'))[0] // find the string containing a reference to "Bcast" (Broadcast IP)
+                      .trim() // remove extra whitespace from either side of the string
+                      .split(' ') // split the string by whitespace between words
+                      .filter((string) => string.includes('Bcast'))[0] // find the string containing a reference to "Bcast"
+                      .split(':')[1]; // split the string by the ":", i.e. "Bcast:10.0.0.11" and grab the number as the 2nd item in that array
 
                     // attempt to parse out the security configuration from the returned network object
                     if (network.encryption.enabled) {

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -2040,6 +2040,14 @@ exports['Tessel.Wifi'] = {
       password: 'TestPassword',
       security: 'wep'
     };
+    var ipResult = `wlan0     Link encap:Ethernet  HWaddr 02:A3:AA:A9:FB:02
+        inet addr:10.0.1.11  Bcast:192.168.1.101  Mask:255.255.255.0
+        inet6 addr: fe80::a3:aaff:fea9:fb02/64 Scope:Link
+        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+        RX packets:2786 errors:0 dropped:0 overruns:0 frame:0
+        TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
+        collisions:0 txqueuelen:1000
+        RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
     var ip = '192.168.1.101';
     var network = {
       ssid: 'TestNetwork',
@@ -2053,7 +2061,7 @@ exports['Tessel.Wifi'] = {
     this.exec.restore();
     this.exec = sandbox.stub(childProcess, 'exec', (cmd, callback) => {
       if (cmd === 'ifconfig wlan0') {
-        callback(null, ip);
+        callback(null, ipResult);
       } else if (cmd === `ubus call iwinfo info '{"device":"wlan0"}'`) {
         callback(null, JSON.stringify(network));
       } else {
@@ -2062,7 +2070,7 @@ exports['Tessel.Wifi'] = {
     });
 
     var results = Object.assign({
-      ips: [ip]
+      ip: ip
     }, settings, network);
     delete results.password;
 
@@ -2106,6 +2114,14 @@ exports['Tessel.Wifi'] = {
       password: 'TestPassword',
       security: 'psk'
     };
+    var ipResult = `wlan0     Link encap:Ethernet  HWaddr 02:A3:AA:A9:FB:02
+        inet addr:10.0.1.11  Bcast:192.168.1.101  Mask:255.255.255.0
+        inet6 addr: fe80::a3:aaff:fea9:fb02/64 Scope:Link
+        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+        RX packets:2786 errors:0 dropped:0 overruns:0 frame:0
+        TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
+        collisions:0 txqueuelen:1000
+        RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
     var ip = '192.168.1.101';
     var network = {
       ssid: 'TestNetwork',
@@ -2120,7 +2136,7 @@ exports['Tessel.Wifi'] = {
     this.exec.restore();
     this.exec = sandbox.stub(childProcess, 'exec', (cmd, callback) => {
       if (cmd === 'ifconfig wlan0') {
-        callback(null, ip);
+        callback(null, ipResult);
       } else if (cmd === `ubus call iwinfo info '{"device":"wlan0"}'`) {
         callback(null, JSON.stringify(network));
       } else {
@@ -2129,7 +2145,7 @@ exports['Tessel.Wifi'] = {
     });
 
     var results = Object.assign({
-      ips: [ip]
+      ip: ip
     }, settings, network);
     delete results.password;
 
@@ -2155,6 +2171,14 @@ exports['Tessel.Wifi'] = {
       ssid: 'TestNetwork',
       password: 'TestPassword'
     };
+    var ipResult = `wlan0     Link encap:Ethernet  HWaddr 02:A3:AA:A9:FB:02
+        inet addr:10.0.1.11  Bcast:192.168.1.101  Mask:255.255.255.0
+        inet6 addr: fe80::a3:aaff:fea9:fb02/64 Scope:Link
+        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+        RX packets:2786 errors:0 dropped:0 overruns:0 frame:0
+        TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
+        collisions:0 txqueuelen:1000
+        RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
     var ip = '192.168.1.101';
     var network = {
       ssid: 'TestNetwork',
@@ -2169,7 +2193,7 @@ exports['Tessel.Wifi'] = {
     this.exec.restore();
     this.exec = sandbox.stub(childProcess, 'exec', (cmd, callback) => {
       if (cmd === 'ifconfig wlan0') {
-        callback(null, ip);
+        callback(null, ipResult);
       } else if (cmd === `ubus call iwinfo info '{"device":"wlan0"}'`) {
         callback(null, JSON.stringify(network));
       } else {
@@ -2178,7 +2202,7 @@ exports['Tessel.Wifi'] = {
     });
 
     var results = Object.assign({
-      ips: [ip],
+      ip: ip,
       security: 'psk2'
     }, settings, network);
     delete results.password;
@@ -2207,6 +2231,14 @@ exports['Tessel.Wifi'] = {
     var settings = {
       ssid: 'TestNetwork'
     };
+    var ipResult = `wlan0     Link encap:Ethernet  HWaddr 02:A3:AA:A9:FB:02
+        inet addr:10.0.1.11  Bcast:192.168.1.101  Mask:255.255.255.0
+        inet6 addr: fe80::a3:aaff:fea9:fb02/64 Scope:Link
+        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+        RX packets:2786 errors:0 dropped:0 overruns:0 frame:0
+        TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
+        collisions:0 txqueuelen:1000
+        RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
     var ip = '192.168.1.101';
     var network = {
       ssid: 'TestNetwork',
@@ -2219,7 +2251,7 @@ exports['Tessel.Wifi'] = {
     this.exec.restore();
     this.exec = sandbox.stub(childProcess, 'exec', (cmd, callback) => {
       if (cmd === 'ifconfig wlan0') {
-        callback(null, ip);
+        callback(null, ipResult);
       } else if (cmd === `ubus call iwinfo info '{"device":"wlan0"}'`) {
         callback(null, JSON.stringify(network));
       } else {
@@ -2228,7 +2260,7 @@ exports['Tessel.Wifi'] = {
     });
 
     var results = Object.assign({
-      ips: [ip],
+      ip: ip,
       security: 'none'
     }, settings, network);
 
@@ -2289,6 +2321,14 @@ exports['Tessel.Wifi'] = {
     var settings = {
       ssid: 'TestNetwork'
     };
+    var ipResult = `wlan0     Link encap:Ethernet  HWaddr 02:A3:AA:A9:FB:02
+        inet addr:10.0.1.11  Bcast:192.168.1.101  Mask:255.255.255.0
+        inet6 addr: fe80::a3:aaff:fea9:fb02/64 Scope:Link
+        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+        RX packets:2786 errors:0 dropped:0 overruns:0 frame:0
+        TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
+        collisions:0 txqueuelen:1000
+        RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
     var ip = '192.168.1.101';
     var network = {
       ssid: 'TestNetwork',
@@ -2302,7 +2342,7 @@ exports['Tessel.Wifi'] = {
     this.exec.restore();
     this.exec = sandbox.stub(childProcess, 'exec', (cmd, callback) => {
       if (cmd === 'ifconfig wlan0') {
-        callback(null, ip);
+        callback(null, ipResult);
       } else if (cmd === `ubus call iwinfo info '{"device":"wlan0"}'`) {
         callback(null, JSON.stringify(network));
       } else if (cmd === `uci get wireless.@wifi-iface[0].disabled`) {
@@ -2318,7 +2358,7 @@ exports['Tessel.Wifi'] = {
     });
 
     var results = Object.assign({
-      ips: [ip],
+      ip: ip,
       security: 'none'
     }, settings, network);
 

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -2387,6 +2387,33 @@ exports['Tessel.Wifi'] = {
   reset: function(test) {
     test.expect(2);
 
+    var ipResult = `wlan0     Link encap:Ethernet  HWaddr 02:A3:AA:A9:FB:02
+        inet addr:10.0.1.11  Bcast:192.168.1.101  Mask:255.255.255.0
+        inet6 addr: fe80::a3:aaff:fea9:fb02/64 Scope:Link
+        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+        RX packets:2786 errors:0 dropped:0 overruns:0 frame:0
+        TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
+        collisions:0 txqueuelen:1000
+        RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
+    var network = {
+      ssid: 'TestNetwork',
+      strength: '30/80',
+      encryption: {
+        enabled: false
+      }
+    };
+
+    this.exec.restore();
+    this.exec = sandbox.stub(childProcess, 'exec', (cmd, callback) => {
+      if (cmd === 'ifconfig wlan0') {
+        callback(null, ipResult);
+      } else if (cmd === `ubus call iwinfo info '{"device":"wlan0"}'`) {
+        callback(null, JSON.stringify(network));
+      } else {
+        callback();
+      }
+    });
+
     this.tessel.network.wifi.on('disconnect', () => {
       test.ok(true, 'disconnect event is fired');
     });
@@ -2423,6 +2450,33 @@ exports['Tessel.Wifi'] = {
 
   enable: function(test) {
     test.expect(1);
+
+    var ipResult = `wlan0     Link encap:Ethernet  HWaddr 02:A3:AA:A9:FB:02
+        inet addr:10.0.1.11  Bcast:192.168.1.101  Mask:255.255.255.0
+        inet6 addr: fe80::a3:aaff:fea9:fb02/64 Scope:Link
+        UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+        RX packets:2786 errors:0 dropped:0 overruns:0 frame:0
+        TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
+        collisions:0 txqueuelen:1000
+        RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
+    var network = {
+      ssid: 'TestNetwork',
+      strength: '30/80',
+      encryption: {
+        enabled: false
+      }
+    };
+
+    this.exec.restore();
+    this.exec = sandbox.stub(childProcess, 'exec', (cmd, callback) => {
+      if (cmd === 'ifconfig wlan0') {
+        callback(null, ipResult);
+      } else if (cmd === `ubus call iwinfo info '{"device":"wlan0"}'`) {
+        callback(null, JSON.stringify(network));
+      } else {
+        callback();
+      }
+    });
 
     this.tessel.network.wifi.on('connect', () => {
       test.ok(true, 'connect event is fired');


### PR DESCRIPTION
Fixes #178 - get connection info from system instead of in-memory cache
Fixes #190 - normalize security value on connection settings to match the standard configuration values, i.e. `none`, `wep`, `psk`, `psk2`
Fixes #192 - set a usable value to the connection `ip` property as opposed to of the seemingly random array of strings as `ips`.

This build changes how the `Wifi.connection` method works, making it an asynchronous request to the system requiring a `callback` argument to return the network settings. This will require a change of the documentation before releasing to the public, with a reference to that release version this change was made.

```js
tessel.network.wifi.connection(callback);

function callback (error, networkSettings) {
  if (error) { throw error; }

  console.log(networkSettings); // should be an object containing the ssid, security, ip, and other network information
}
```

Smoke test:
Update a Tessel with the `node/teasel-export.js` from this PR. (See [this gist](https://gist.github.com/HipsterBrown/d0d24e9e1867ef4e5bb3) for how to do this using `sip`)

`mkdir t2-firmware-178`
`cd t2-firmware-178`
`t2 init`
`t2 wifi --ssid YourWifiNetwork --pass PasswordIfNeeded`

Replace the content of index.js with the following:

```js
// Import the interface to Tessel hardware
var tessel = require('tessel');

tessel.network.wifi.connection((error, settings) => {
  console.log('Callback!');

  if (error) {
    console.log(error);
  } else {
    console.log('Settings: ', settings);
  }
});
```

`t2 run index.js`

You should get a result like the following:

```
hipsterbrown:t2-firmware-178 $ t2 run index.js
INFO Looking for your Tessel...
INFO Connected to tessel-router.
INFO Building project.
INFO Writing project to RAM on tessel-router (3.072 kB)...
INFO Deployed.
INFO Running index.js...
INFO Connected to tessel-router.
Callback!
Settings:  { phy: 'phy0',
  ssid: 'Speak Friend',
  bssid: '54:E4:3A:E8:A0:1C',
  country: '00',
  mode: 'Client',
  channel: 1,
  frequency: 2412,
  txpower: 20,
  quality: 65,
  quality_max: 70,
  signal: -45,
  bitrate: 43300,
  encryption:
   { enabled: true,
     wpa: [ 2 ],
     authentication: [ 'psk' ],
     ciphers: [ 'ccmp' ] },
  hwmodes: [ 'b', 'g', 'n' ],
  hardware: { name: 'Generic MAC80211' },
  ip: '10.0.1.255',
  security: 'psk2' }
```

Pinging at least @rwaldron, @reconbot, @johnnyman727 for review and/or smoke testing.