### PR TITLE
Implements Tessel.prototype.reboot(). Closes gh-188

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -22,6 +22,8 @@ const PWM_MIN_FREQUENCY = 1;
 const PWM_PRESCALARS = [1, 2, 4, 8, 16, 64, 256, 1024];
 // Maximum number of unscaled ticks in a second (48 MHz)
 const SAMD21_TICKS_PER_SECOND = 48000000;
+// GPIO number of RESET pin
+const SAMD21_RESET_GPIO = 39;
 
 function Tessel(options) {
   if (Tessel.instance) {
@@ -124,6 +126,7 @@ Tessel.prototype.open = function(portName) {
 };
 
 Tessel.prototype.reboot = function() {
+
   this.close();
 
   // When attempting to reboot, if the sockets
@@ -136,6 +139,18 @@ Tessel.prototype.reboot = function() {
   var pollUntilSocketsDestroyed = () => {
     if (this.port.A.sock.destroyed &&
       this.port.B.sock.destroyed) {
+
+      // Stop SPI communication between SAMD21 and MediaTek
+      childProcess.execSync('/etc/init.d/spid stop');
+
+      // Create a GPIO entry for the SAMD21 RESET pin
+      childProcess.execSync(`echo "${SAMD21_RESET_GPIO}" > /sys/class/gpio/export`);
+      // Make that GPIO an output
+      childProcess.execSync(`echo "out" > /sys/class/gpio/gpio${SAMD21_RESET_GPIO}/direction`);
+      // Pull the output low to reset the SAMD21
+      childProcess.execSync(`echo "0" > /sys/class/gpio/gpio${SAMD21_RESET_GPIO}/value`);
+
+      // Reboot the MediaTek
       childProcess.execSync('reboot');
     } else {
       setImmediate(pollUntilSocketsDestroyed);

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -272,7 +272,7 @@ exports['Tessel.prototype'] = {
   },
 
   reboot: function(test) {
-    test.expect(3);
+    test.expect(7);
 
     var close = sandbox.stub(this.tessel, 'close');
     var execSync = sandbox.stub(childProcess, 'execSync');
@@ -288,7 +288,11 @@ exports['Tessel.prototype'] = {
     this.tessel.reboot();
 
     test.equal(close.callCount, 1);
-    test.equal(execSync.callCount, 1);
+    test.equal(execSync.callCount, 5);
+    test.equal(execSync.getCall(0).args[0], '/etc/init.d/spid stop');
+    test.equal(execSync.getCall(1).args[0], 'echo "39" > /sys/class/gpio/export');
+    test.equal(execSync.getCall(2).args[0], 'echo "out" > /sys/class/gpio/gpio39/direction');
+    test.equal(execSync.getCall(3).args[0], 'echo "0" > /sys/class/gpio/gpio39/value');
     test.equal(execSync.lastCall.args[0], 'reboot');
     test.done();
   },

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -59,6 +59,94 @@ exports['Tessel'] = {
     test.done();
   },
 
+  portsAliasToPort: function(test) {
+    test.expect(1);
+    test.equal(this.tessel.port, this.tessel.ports);
+    test.done();
+  },
+
+  twoPortsInitialized: function(test) {
+    test.expect(5);
+    test.equal(this.tessel.ports.A instanceof Tessel.Port, true);
+    test.equal(this.tessel.ports.B instanceof Tessel.Port, true);
+    test.equal(this.Port.callCount, 2);
+    test.deepEqual(this.Port.firstCall.args, ['A', '/var/run/tessel/port_a', this.tessel]);
+    test.deepEqual(this.Port.lastCall.args, ['B', '/var/run/tessel/port_b', this.tessel]);
+    test.done();
+  },
+
+  ledsLazyInitialization: function(test) {
+    test.expect(3);
+    test.equal(this.LED.callCount, 0);
+    // Trigger a [[Get]]
+    test.equal(this.tessel.led[0] instanceof Tessel.LED, true);
+    test.equal(this.LED.callCount, 1);
+    test.done();
+  },
+
+  ledsLazyInitializedAndOff: function(test) {
+    test.expect(5);
+    test.equal(this.tessel.led[0].value, 0);
+    test.equal(this.fsWrite.callCount, 1);
+    test.equal(this.fsWrite.lastCall.args[0], '/sys/devices/leds/leds/tessel:red:error/brightness');
+    test.equal(this.fsWrite.lastCall.args[1], '0');
+    test.equal(this.LED.callCount, 1);
+    test.done();
+  },
+
+  fourLEDsInitialized: function(test) {
+    test.expect(9);
+    test.equal(this.tessel.led[0] instanceof Tessel.LED, true);
+    test.equal(this.tessel.led[1] instanceof Tessel.LED, true);
+    test.equal(this.tessel.led[2] instanceof Tessel.LED, true);
+    test.equal(this.tessel.led[3] instanceof Tessel.LED, true);
+    test.equal(this.LED.callCount, 4);
+    test.deepEqual(
+      this.LED.getCall(0).args, ['red', '/sys/devices/leds/leds/tessel:red:error/brightness']
+    );
+    test.deepEqual(
+      this.LED.getCall(1).args, ['amber', '/sys/devices/leds/leds/tessel:amber:wlan/brightness']
+    );
+    test.deepEqual(
+      this.LED.getCall(2).args, ['green', '/sys/devices/leds/leds/tessel:green:user1/brightness']
+    );
+    test.deepEqual(
+      this.LED.getCall(3).args, ['blue', '/sys/devices/leds/leds/tessel:blue:user2/brightness']
+    );
+
+    test.done();
+  },
+
+  networkWifiInitialized: function(test) {
+    test.expect(1);
+    test.equal(this.tessel.network.wifi instanceof Tessel.Wifi, true);
+
+    test.done();
+  },
+
+  tesselVersion: function(test) {
+    test.expect(1);
+    test.equal(this.tessel.version, version);
+    test.done();
+  },
+};
+
+exports['Tessel.prototype'] = {
+  setUp: function(done) {
+    this.LED = sandbox.spy(Tessel, 'LED');
+    this.Port = sandbox.stub(Tessel, 'Port');
+    this.fsWrite = sandbox.stub(fs, 'writeFile');
+
+    this.tessel = new Tessel();
+    done();
+  },
+
+  tearDown: function(done) {
+    Tessel.instance = null;
+    sandbox.restore();
+    done();
+  },
+
   closeBoth: function(test) {
     test.expect(1);
 
@@ -183,74 +271,25 @@ exports['Tessel'] = {
     test.done();
   },
 
-  portsAliasToPort: function(test) {
-    test.expect(1);
-    test.equal(this.tessel.port, this.tessel.ports);
-    test.done();
-  },
-
-  twoPortsInitialized: function(test) {
-    test.expect(5);
-    test.equal(this.tessel.ports.A instanceof Tessel.Port, true);
-    test.equal(this.tessel.ports.B instanceof Tessel.Port, true);
-    test.equal(this.Port.callCount, 2);
-    test.deepEqual(this.Port.firstCall.args, ['A', '/var/run/tessel/port_a', this.tessel]);
-    test.deepEqual(this.Port.lastCall.args, ['B', '/var/run/tessel/port_b', this.tessel]);
-    test.done();
-  },
-
-  ledsLazyInitialization: function(test) {
+  reboot: function(test) {
     test.expect(3);
-    test.equal(this.LED.callCount, 0);
-    // Trigger a [[Get]]
-    test.equal(this.tessel.led[0] instanceof Tessel.LED, true);
-    test.equal(this.LED.callCount, 1);
-    test.done();
-  },
 
-  ledsLazyInitializedAndOff: function(test) {
-    test.expect(5);
-    test.equal(this.tessel.led[0].value, 0);
-    test.equal(this.fsWrite.callCount, 1);
-    test.equal(this.fsWrite.lastCall.args[0], '/sys/devices/leds/leds/tessel:red:error/brightness');
-    test.equal(this.fsWrite.lastCall.args[1], '0');
-    test.equal(this.LED.callCount, 1);
-    test.done();
-  },
+    var close = sandbox.stub(this.tessel, 'close');
+    var execSync = sandbox.stub(childProcess, 'execSync');
+    var destroyed = true;
 
-  fourLEDsInitialized: function(test) {
-    test.expect(9);
-    test.equal(this.tessel.led[0] instanceof Tessel.LED, true);
-    test.equal(this.tessel.led[1] instanceof Tessel.LED, true);
-    test.equal(this.tessel.led[2] instanceof Tessel.LED, true);
-    test.equal(this.tessel.led[3] instanceof Tessel.LED, true);
-    test.equal(this.LED.callCount, 4);
-    test.deepEqual(
-      this.LED.getCall(0).args, ['red', '/sys/devices/leds/leds/tessel:red:error/brightness']
-    );
-    test.deepEqual(
-      this.LED.getCall(1).args, ['amber', '/sys/devices/leds/leds/tessel:amber:wlan/brightness']
-    );
-    test.deepEqual(
-      this.LED.getCall(2).args, ['green', '/sys/devices/leds/leds/tessel:green:user1/brightness']
-    );
-    test.deepEqual(
-      this.LED.getCall(3).args, ['blue', '/sys/devices/leds/leds/tessel:blue:user2/brightness']
-    );
+    this.tessel.port.A.sock = {
+      destroyed
+    };
+    this.tessel.port.B.sock = {
+      destroyed
+    };
 
-    test.done();
-  },
+    this.tessel.reboot();
 
-  networkWifiInitialized: function(test) {
-    test.expect(1);
-    test.equal(this.tessel.network.wifi instanceof Tessel.Wifi, true);
-
-    test.done();
-  },
-
-  tesselVersion: function(test) {
-    test.expect(1);
-    test.equal(this.tessel.version, version);
+    test.equal(close.callCount, 1);
+    test.equal(execSync.callCount, 1);
+    test.equal(execSync.lastCall.args[0], 'reboot');
     test.done();
   },
 };


### PR DESCRIPTION
- Closes ports before executing `reboot`


## Smoke Tests

1. Pull this branch local
2. With a T2 connected via LAN, run: 
    ```
    scp -i /PATH/TO/t2-firmware/node/tessel-export.js root@[NAME OF YOUR TESSEL].local:/usr/lib/node/tessel-export.js
    ```
(make the appropriate changes)
3. Create a new project: 
    ```
    t2 init
    ```

4. Paste this into `index.js`: 
    ```js
    var tessel = require("tessel");

    // Turn one of the LEDs on to start.
    tessel.led[2].on();

    // Blink!
    setInterval(function () {
      tessel.led[2].toggle();
      tessel.led[3].toggle();
    }, 100);

    console.log("I'm blinking! (Press CTRL + C to stop)");
    console.log("In 2 seconds, I will reboot this Tessel.");

    setTimeout(() => tessel.reboot(), 2000);
    ```



Expected outcome: 

```
$ t2 run index.js
INFO Looking for your Tessel...
INFO Connected to bruno.
INFO Building project.
INFO Writing project to RAM on bruno (3.072 kB)...
INFO Deployed.
INFO Running index.js...
I'm blinking! (Press CTRL + C to stop)
In 2 seconds, I will reboot this Tessel.
```

You should see, on the T2 itself: 

1. Both ports light
2. LED 2 & 3 are blinking
3. After 2 seconds, Both ports shut off 
4. The Tessel reboots



Signed-off-by: Rick Waldron <waldron.rick@gmail.com>