### PR TITLE
Switch order of self.emit to fix issue with RFID

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -274,11 +274,11 @@ Tessel.Port = function(name, socketPath, board) {
 
           // For one-time 'low' or 'high' event
           if (mode === 'low' || mode === 'high') {
-            pin.emit(mode);
             // Reset the pin interrupt state (prevent constant interrupts)
             pin.interruptMode = null;
             // Decrement the number of tasks waiting on the socket
             this.unref();
+            pin.emit(mode);
           } else {
             // Emit the change and rise or fall
             pin.emit('change', pinValue);


### PR DESCRIPTION
To be completely honest most of this is way over my head, but I've managed to fix https://github.com/tessel/rfid-pn532/issues/30

As I understand it, with the v0.0.13 firmware update the order that some pin.emit events were being fired. Specifically v0.0.13 cause `pin.emit('low')` to be fired before this code:

```js
// Reset the pin interrupt state (prevent constant interrupts)
pin.interruptMode = null;
// Decrement the number of tasks waiting on the socket
this.unref();
```

This re-ordering of code was causing an error in the RFID module code: Error: packet improperly formed on line 651.

https://github.com/tessel/rfid-pn532/blob/master/index.js#L651

Since I don't have the hardware context to know exactly what this code is doing I'm not sure if changing the order back will cause any other unexpected problems. but I do know that this small change fixes the RFID module, which I have tested.

Happy to make any other changes necessary if this is not the correct fix.