### PR TITLE
Implements button reset

### DIFF
--- a/common/hw.h
+++ b/common/hw.h
@@ -266,3 +266,7 @@ inline static void wdt_reset(u32 clock_channel) {
   WDT->CONFIG.reg = 0x7; // 31ms
   WDT->CTRL.reg = WDT_CTRL_ENABLE;
 }
+
+inline static void sys_reset() {
+  NVIC_SystemReset();
+}

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -157,7 +157,7 @@ void boot_delay_ms(int delay){
 }
 
 int main(void) {
-    if (PM->RCAUSE.reg & (PM_RCAUSE_POR | PM_RCAUSE_BOD12 | PM_RCAUSE_BOD33)) {
+    if (PM->RCAUSE.reg & (PM_RCAUSE_POR | PM_RCAUSE_BOD12 | PM_RCAUSE_BOD33 | PM_RCAUSE_SYST)) {
         // On powerup, force a clean reset of the MT7620
         pin_low(PIN_SOC_RST);
         pin_out(PIN_SOC_RST);


### PR DESCRIPTION
Use the SAMD21 POR routine to cleanly & deterministically reset the board