### PR TITLE
[WIP] Adds delay command to firmware

### DIFF
--- a/common/board.h
+++ b/common/board.h
@@ -85,6 +85,7 @@ typedef struct TesselPort {
     u32 spi_dipo;
     u32 uart_dopo;
     u32 uart_dipo;
+    TimerId delay_id;
 } TesselPort;
 
 #define SERCOM_PORT_A_SPI 5
@@ -113,6 +114,8 @@ const static TesselPort PORT_A = {
     .spi_dopo = 3,
     .uart_dipo = 3,
     .uart_dopo = 1,
+    // TODO: figure out how to link to #define in firmware.h
+    .delay_id = 5,
 };
 
 const static TesselPort PORT_B = {
@@ -136,4 +139,6 @@ const static TesselPort PORT_B = {
     .spi_dopo = 0,
     .uart_dipo = 3,
     .uart_dopo = 1,
+    // TODO: figure out how to link to #define in firmware.h
+    .delay_id = 1,
 };

--- a/firmware/firmware.h
+++ b/firmware/firmware.h
@@ -38,10 +38,19 @@
 #define TC_TERMINAL_TIMEOUT 3
 #define TC_BOOT             4
 
+// Used for CMD_WAIT command on port A
+#define TC_DELAY_PORT_A     5
+
 // TCC allocation
 // muxed with i2c. also used for uart read timers
 #define TCC_PORT_A 2 // PA12, PA13
 #define TCC_PORT_B 0 // PA08, PA09
+
+// TCC 1 is first used for the boot led
+// but once the MediaTek is booted, we
+// use it as the delay TCC for port B
+#define PWR_LED_TCC_CHAN 1
+#define TCC_DELAY_PORT_B 1
 
 // GCLK channel allocation
 #define GCLK_SYSTEM 0
@@ -188,6 +197,7 @@ void port_dma_rx_completion(PortData* p);
 void port_dma_tx_completion(PortData* p);
 void port_handle_sercom_uart_i2c(PortData* p);
 void port_handle_extint(PortData *p, u32 flags);
+void port_handle_delay_complete(PortData *p);
 void port_disable(PortData *p);
 void uart_send_data(PortData *p);
 


### PR DESCRIPTION
In order to have a delay function, we need two timers so that both ports can run delays at the same time. We only had one unused timer left so I had to "recycle" the timer we use for the boot LED animation sequence (TCC1). Also, I renamed the unimplemented `CMD_GPIO_WAIT` to the more generic `CMD_WAIT`. 

This still does not work. I was testing with the following function and a logic analyzer to confirm delay time:

```
var tessel = require('tessel');

function delayTest(port, delayTime) {
  port.digital[1].low();
  port.delay(delayTime); 
  port.digital[1].high();
}

delayTest(tessel.port.A, 10000);
```

I immediately get the following error:

```
Received unexpected response with no commands pending: 130
<stack trace>
```

130 equals 0x82 which correlates to `PortReply.REPLY_HIGH`.

Also, running the same function repeatedly results in an inconsistent delay that usually is not related to the delay time I requested.

It would be useful to get more eyes on this to try to figure out what I'm doing incorrectly.
