### PR TITLE
Get correct address from wifi connection data

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -1505,7 +1505,7 @@ function isEnabled() {
 function getWifiInfo() {
   return new Promise((resolve, reject) => {
     var checkCount = 0;
-    var rbcast = /(Bcast):([\w\.]+)/;
+    var rbcast = /(inet addr):([\w\.]+)/;
 
     function recursiveWifi() {
       childProcess.exec(`ubus call iwinfo info '{"device":"wlan0"}'`, (error, results) => {
@@ -1541,15 +1541,15 @@ function getWifiInfo() {
         if (error) {
           reject(error);
         } else {
-          var bcastMatches = ipResults.match(rbcast);
+          var inetMatches = ipResults.match(rbcast);
 
-          if (bcastMatches === null) {
+          if (inetMatches === null) {
             recursiveWifi(network);
           } else {
             // Successful matches will have a result that looks like: 
-            // ["Bcast:0.0.0.0", "Bcast", "0.0.0.0"]
-            if (bcastMatches.length === 3) {
-              network.ip = bcastMatches[2];
+            // ["inet addr:0.0.0.0", "inet addr", "0.0.0.0"]
+            if (inetMatches.length === 3) {
+              network.ip = inetMatches[2];
             } else {
               recursiveWifi(network);
             }

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -2519,7 +2519,7 @@ exports['Tessel.Wifi'] = {
         TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:1000
         RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
-    var ip = '192.168.1.101';
+    var ip = '10.0.1.11';
     var network = {
       ssid: 'TestNetwork',
       strength: '30/80',
@@ -2593,7 +2593,7 @@ exports['Tessel.Wifi'] = {
         TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:1000
         RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
-    var ip = '192.168.1.101';
+    var ip = '10.0.1.11';
     var network = {
       ssid: 'TestNetwork',
       strength: '30/80',
@@ -2650,7 +2650,7 @@ exports['Tessel.Wifi'] = {
         TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:1000
         RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
-    var ip = '192.168.1.101';
+    var ip = '10.0.1.11';
     var network = {
       ssid: 'TestNetwork',
       strength: '30/80',
@@ -2710,7 +2710,7 @@ exports['Tessel.Wifi'] = {
         TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:1000
         RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
-    var ip = '192.168.1.101';
+    var ip = '10.0.1.11';
     var network = {
       ssid: 'TestNetwork',
       strength: '30/80',
@@ -2767,7 +2767,7 @@ exports['Tessel.Wifi'] = {
         TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:1000
         RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
-    var ip = '192.168.1.101';
+    var ip = '10.0.1.11';
     var network = {
       ssid: 'TestNetwork',
       strength: '30/80'
@@ -2854,7 +2854,7 @@ exports['Tessel.Wifi'] = {
         TX packets:493 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:1000
         RX bytes:833626 (814.0 KiB)  TX bytes:97959 (95.6 KiB)`;
-    var ip = '192.168.1.101';
+    var ip = '10.0.1.11';
     var network = {
       ssid: 'TestNetwork',
       strength: '30/80',


### PR DESCRIPTION
Fixes #219 

**Smoke test:**
Push the new node module to your Tessel using `scp`, [check out this gist](https://gist.github.com/HipsterBrown/d0d24e9e1867ef4e5bb3) to learn more. 

- `mkdir t2-test && cd t2-test`
- `t2 init`
- Connect your Tessel to a wifi network
- Replace the contents of the `index.js` file with the following:

```
var tessel = require('tessel');
tessel.network.wifi.connection(console.log.bind(console));
```

- `t2 run index.js`

You should get output like the following:

```
INFO Looking for your Tessel...
INFO Connected to tessel-router.
INFO Building project.
INFO Writing project to RAM on tessel-router (226.816 kB)...
INFO Deployed.
INFO Running test.js...
null { phy: 'phy0',
  ssid: 'Speak Friend',
  bssid: '54:E4:3A:E8:A0:1C',
  country: '00',
  mode: 'Client',
  channel: 6,
  frequency: 2437,
  txpower: 20,
  quality: 59,
  quality_max: 70,
  signal: -51,
  bitrate: 43300,
  encryption:
   { enabled: true,
     wpa: [ 2 ],
     authentication: [ 'psk' ],
     ciphers: [ 'ccmp' ] },
  hwmodes: [ 'b', 'g', 'n' ],
  hardware: { name: 'Generic MAC80211' },
  ip: '10.0.1.11',
  security: 'psk2' }
```

With the `ip` property matching the same address as what is returned by the `t2 wifi` command, i.e. 

```
INFO Looking for your Tessel...
INFO Connected to tessel-router.
INFO Connected to "Speak Friend"
INFO IP Address: 10.0.1.11
INFO Signal Strength: (55/70)
INFO Bitrate: 65mbps
```