### PR TITLE
Travis: add Node 8, remove Node 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - "4"
-  - "5"
   - "6"
+  - "8"
 before_install:
   - cd node
   - npm install -g grunt-cli


### PR DESCRIPTION
As we prepare for a release of t2-firmware to support Node 8, this PR adds that version to our Travis CI configuration. 