### PR TITLE
I don't know why, but this fixes the build

### DIFF
--- a/firmware/port.c
+++ b/firmware/port.c
@@ -642,7 +642,7 @@ void port_disable_async_events(PortData *p) {
 }
 
 /// Return true if the port is in a state where it can handle asyncronous events
-inline bool port_async_events_allowed(PortData* p) {
+bool port_async_events_allowed(PortData* p) {
     if (!p->pending_in) {
         if (p->state == PORT_READ_CMD) return true;
 


### PR DESCRIPTION
I was getting this error building the firmware on a Mac OS X Mojave Beta:

```
/var/folders/5n/kqr_3l4d3n56b9s1xlvh_tsr0000gn/T//ccIS8P05.ltrans0.ltrans.o: In function `port_step':
/Users/nodebotanist/Code/bots/tessel/t2-firmware/firmware/port.c:683: undefined reference to `port_async_events_allowed'
/var/folders/5n/kqr_3l4d3n56b9s1xlvh_tsr0000gn/T//ccIS8P05.ltrans0.ltrans.o: In function `port_handle_sercom_uart_i2c':
/Users/nodebotanist/Code/bots/tessel/t2-firmware/firmware/port.c:775: undefined reference to `port_async_events_allowed'
collect2: error: ld returned 1 exit status
make: *** [build/firmware.elf] Error 1
```

When I made this change, it started working correctly. Not entirely sure why...?

Note: ran on High Sierra, still worked and built.