### PR TITLE
Extended maximum UART baud rate from 115200 to 230400

### DIFF
--- a/node/tessel-export.js
+++ b/node/tessel-export.js
@@ -1185,8 +1185,8 @@ class UART extends Duplex {
           // samples_per_bit = 16, 8, or 3
           // f_ref = 48e6
 
-          if (value < 9600 || value > 115200) {
-            throw new Error('UART baudrate must be between 9600 and 115200');
+          if (value < 9600 || value > 230400) {
+            throw new Error('UART baudrate must be between 9600 and 230400');
           }
 
           baudrate = value;

--- a/node/test/unit/tessel.js
+++ b/node/test/unit/tessel.js
@@ -2760,7 +2760,7 @@ exports['Tessel.UART'] = {
       baudrate: b1
     });
 
-    test.throws(() => uart.baudrate = 115201);
+    test.throws(() => uart.baudrate = 230401);
     test.equal(uart.baudrate, b1);
 
     test.done();


### PR DESCRIPTION
We've been successfully running the UART at 230400 baud on hundreds of Tessels for a few years now, would be lovely to include support for this in the official firmware.  This pull request simply extends the max value from 115200 to 230400 baud.